### PR TITLE
Leave the encoding of ' ' alone. (%20, not %2B)

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -31,7 +31,7 @@ Query.prototype.q = function(q){
    var self = this;
    var parameter ='q=';
    if ( typeof(q) === 'string' ){
-      parameter += encodeURIComponent(q.split(' ').join('+'));
+      parameter += encodeURIComponent(q);
    }else{
       parameter += querystring.stringify(q, '%20',':');
    }


### PR DESCRIPTION
It seems the solr query parser treats '+' very differently from a space.

```
AssertionError: expected [Error: SORL ERROR: Error 400 org.apache.lucene.queryParser.ParseException: Cannot parse 'topics:+Sports': Encountered " "+" "+ "" at line 1, column 7.
```

It works perfectly fine when space is properly encoded as %20.
