### PR TITLE
Fix in rangeFilter and in q functions

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -100,7 +100,7 @@ Query.prototype.q = function(q){
    if ( typeof(q) === 'string' ){
       parameter += encodeURIComponent(q);
    }else{
-      parameter += querystring.stringify(q, '%20',':');
+      parameter += querystring.stringify(q, '%20AND%20',':');
    }
    this.parameters.push(parameter);
    return self;
@@ -233,7 +233,7 @@ Query.prototype.sort = function(options){
 }
 
 /**
- * Filter the set of documents found before to return the result with the given range determined by `field`, `start` and `end`.
+ * Filter the set of documents found before to return the result with the given range determined by `field`, `start` and `stop`.
  * 
  * @param {Array|Object} options -
  * @param {String} options.field - the name of the field where the range is applied
@@ -245,9 +245,9 @@ Query.prototype.sort = function(options){
  *
  * @example
  * var query = client.createQuery();
- * query.q({ '*' : '*' }).rangeFilter({ field : 'id', start : 100, end : 200})
+ * query.q({ '*' : '*' }).rangeFilter({ field : 'id', start : 100, stop : 200})
  * // also works
- * query.q({ '*' : '*' }).rangeFilter([{ field : 'id', start : 100, end : 200},{ field : 'date', start : new Date(), end : new Date() - 3600}]);
+ * query.q({ '*' : '*' }).rangeFilter([{ field : 'id', start : 100, stop : 200},{ field : 'date', start : new Date(), stop : new Date() - 3600}]);
  */
 
 Query.prototype.rangeFilter = function(options){
@@ -255,13 +255,15 @@ Query.prototype.rangeFilter = function(options){
    options = format.dateISOify(options);
    var parameter = 'fq=';
    if(Array.isArray(options)){
+     parameter += "(";
       var filters = options.map(function(option){
          var key = option.field;
          var filter = {};
          filter[key] = '[' + encodeURIComponent(option.start) + '%20TO%20' + encodeURIComponent(option.end) + ']';
          return format.stringify(filter, '',':');
       });
-      parameter += filters.join('%20'); 
+      parameter += filters.join('%20AND%20'); 
+      parameter += ")";
    }else{
       var key = options.field;
       var filter = {};
@@ -548,3 +550,4 @@ Query.prototype.bf = function(){}
 Query.prototype.build = function(){
    return this.parameters.join('&');
 }
+


### PR DESCRIPTION
When using multiple parameters in query (q) - the selected result was wrong. After adding %20AND%20 between each parameter - that fixed the issue. 
Simmilar thing in function rangeFilter - separate parameters by %20AND%20 and added brackets around the fq. 
