### PR TITLE
"Invalid Date" object triggers a show-stopping error

### DIFF
--- a/lib/utils/format.js
+++ b/lib/utils/format.js
@@ -1,43 +1,51 @@
 /**
- * Expose `dateISOify()`
- */ 
+ * Expose `dateISOify()` and `toISOString()`
+ */
 
 exports.dateISOify = dateISOify;
+exports.toISOString = toISOString;
 
 /**
- * ISOify `Date` objects
+ * ISOify `Date` objects (possibly in collections)
  *
  * @param {Array|Object} obj
  *
  * @return {Array|Object}
  * @api private
- */ 
- 
+ */
+
 function dateISOify(obj){
    if( obj instanceof Array ){
       for(var i = 0; i < obj.length; i++){
-         if(obj[i] instanceof Object && !(obj[i] instanceof Date) ){
-            for(var key in obj[i]){
-               if( obj[i][key] instanceof Date ) obj[i][key] = obj[i][key].toISOString();   
-            }
-         }else{
-            if( obj[i] instanceof Date ) obj[i] = obj[i].toISOString();
-         }
+         obj[i] = dateISOify(obj[i]);
       }
    }else if(obj instanceof Object && !(obj instanceof Date) ){
       for(var key in obj){
-         if( obj[key] instanceof Date ) obj[key] = obj[key].toISOString();   
+         if( obj[key] instanceof Date ) obj[key] = toISOString(obj[key]);
       }
    }else{
-      if( obj instanceof Date ) obj = obj.toISOString();
+      if( obj instanceof Date ) obj = toISOString(obj);
    }
    return obj;
 };
 
 /**
+ * ISOify a single `Date` object
+ * Sidesteps `Invalid Date` objects by returning `null` instead
+ *
+ * @param {Date}
+ *
+ * @return {null|String}
+ * @api private
+ */
+function toISOString(date) {
+   return (date && !isNaN(date.getTime())) ? date.toISOString() : null;
+};
+
+/**
  * Expose `stringify()`
  */
- 
+
 exports.stringify = stringify;
 
 /**
@@ -51,7 +59,7 @@ exports.stringify = stringify;
  * @return {String}
  * @api private
  */
- 
+
 function stringify(obj, sep, eq, name) {
   sep = sep || '&';
   eq = eq || '=';
@@ -83,7 +91,7 @@ function stringify(obj, sep, eq, name) {
 /**
  * Stringify a primitive
  *
- * @param {String|Boolean|Number} v - primitive value 
+ * @param {String|Boolean|Number} v - primitive value
  *
  * @return {String}
  * @api private
@@ -103,4 +111,3 @@ function stringifyPrimitive(v) {
       return '';
   }
 };
-

--- a/test/test-util.js
+++ b/test/test-util.js
@@ -1,0 +1,64 @@
+// Dependencies
+var format = require('../lib/utils/format');
+   vows = require('vows'),
+   assert = require('assert');
+
+//nock.recorder.rec();
+
+// Suite Test
+
+var suite = vows.describe('Solr Client Utilities');
+
+suite.addBatch({
+   'format' : {
+      'dateISOify()' : {
+         'when an array is used' : {
+            topic : function() {
+               return format.dateISOify([
+                  {
+                     id:    1,
+                     date1: new Date()
+                  },
+                  {
+                     id:    2,
+                     date1: new Date()
+                  }
+               ]);
+            },
+            'it should replace all nested date objects with strings' : function(list) {
+               assert.equal(typeof list[0].date1, "string");
+               assert.equal(typeof list[1].date1, "string");
+            }
+         },
+         'when an object is used' : {
+            topic : function() {
+               return format.dateISOify({
+                  id:    1,
+                  date1: new Date()
+               });
+            },
+            'it should replace all nested date objects with strings' : function(doc) {
+               assert.equal(typeof doc.date1, "string");
+            }
+         },
+         'when a date object itself is used' : {
+            topic : function() {
+               return format.dateISOify(new Date());
+            },
+            'it should return a string' : function (date) {
+               assert.equal(typeof date, "string");
+            }
+         }
+      },
+      'toISOString()' : {
+         'when invalid date objects are found' : {
+            topic : function() {
+               return format.toISOString(new Date("0000-00-00"));
+            },
+            'it should be replaced by null' : function(date){
+               assert.strictEqual(date, null);
+            }
+         }
+      }
+   }
+}).export(module);


### PR DESCRIPTION
I was importing data from mysql to solr, and if I happened to have a date in my mysql table such as `0000-00-00 00:00:00`, then the `Date` object would become an "Invalid Date" and triggers a fatal error when trying to call `Date#toISOString()`.

This branch will check any `Date` object, replacing an "Invalid Date" with `null` and proceeding as normal for all others. I've also added a new test file for "utils" and have added basic tests for both `dateISOify()` and `toISOString()`.
