### PR TITLE
Add support for multiple facet.field values

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -326,7 +326,7 @@ Query.prototype.group = function(options){
  * @param {Object} options - set of options to create a facet
  * @param {Boolean} [options.on=true] - Turn on or off facet
  * @param {String} [options.query] - This parameter allows you to specify an arbitrary query in the Lucene default syntax to generate a facet count. By default, faceting returns a count of the unique terms for a "field", while facet.query allows you to determine counts for arbitrary terms or expressions.
- * @param {String} options.field - This parameter allows you to specify a field which should be treated as a facet. It will iterate over each Term in the field and generate a facet count using that Term as the constraint.
+ * @param {String|Array} options.field - This parameter allows you to specify a field which should be treated as a facet. It will iterate over each Term in the field and generate a facet count using that Term as the constraint. Multiple fields can be defined providing an array instead of a string.
  * @param {String} [options.prefix] - Limits the terms on which to facet to those starting with the given string prefix.
  * @param {String} [options.sort] - This param determines the ordering of the facet field constraints.count
  * @param {Number} [options.limit=100] - This parameter indicates the maximum number of constraint counts that should be returned for the facet fields. A negative value means unlimited.The solr's default value is 100.
@@ -349,7 +349,12 @@ Query.prototype.facet = function(options){
       this.parameters.push('facet.query=' + encodeURIComponent(options.query))
    }
    if(options.field){
-      this.parameters.push('facet.field=' + options.field)
+      if(!Array.isArray(options.field)){
+         options.field = [options.field];
+      }
+      for (var i = 0; i < options.field.length; i++) {
+         this.parameters.push('facet.field=' + options.field[i])
+      }
    }
    if(options.prefix){
       this.parameters.push('facet.prefix=' + encodeURIComponent(options.prefix))

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -203,6 +203,16 @@ exports.facet = function(nock){
 
 }
 
+exports.facetMultiple = function(nock){
+	nock('http://127.0.0.1:8983')
+	.get('/solr/select?q=*:*&rows=0&facet=true&facet.query=title%3AIpad&facet.field=title&facet.field=description&facet.prefix=Ipa&facet.sort=count&facet.limit=20&facet.offset=0&facet.mincount=0&facet.missing=false&facet.method=fc&wt=json')
+  .reply(200, "{\"responseHeader\":{\"status\":0,\"QTime\":12,\"params\":{\"facet.missing\":\"false\",\"facet\":\"true\",\"facet.mincount\":\"0\",\"facet.offset\":\"0\",\"facet.limit\":\"20\",\"wt\":\"json\",\"facet.method\":\"fc\",\"rows\":\"0\",\"facet.sort\":\"count\",\"facet.query\":\"title:Ipad\",\"q\":\"*:*\",\"facet.prefix\":\"Ipa\",\"facet.field\":\"title\"}},\"response\":{\"numFound\":10,\"start\":0,\"docs\":[]},\"facet_counts\":{\"facet_queries\":{\"title:Ipad\":0},\"facet_fields\":{\"title\":[],\"description\":[]},\"facet_dates\":{},\"facet_ranges\":{}}}", { date: 'Sun, 06 May 2012 22:11:56 GMT',
+  'content-type': 'application/json; charset=UTF-8',
+  connection: 'close',
+  server: 'Jetty(7.5.3.v20111011)' });
+
+}
+
 exports.group = function(nock){
 	nock('http://127.0.0.1:8983')
 	.get('/solr/select?q=description:laptop&group=true&group.field=title&group.limit=20&group.offset=0&group.sort=score%20asc&group.format=grouped&group.main=false&group.ngroups=true&group.truncate=false&group.cache.percent=0&wt=json')

--- a/test/test-facet.js
+++ b/test/test-facet.js
@@ -12,6 +12,7 @@ var config = JSON.parse(fs.readFileSync(__dirname + '/config.json'));
 if(config.mocked){
    //nock.recorder.rec();
    mocks.facet(nock);
+   mocks.facetMultiple(nock);
 }
 
 // Suite Test
@@ -42,9 +43,33 @@ suite.addBatch({
          'should return a correct response without error' :function(err,res) {
             assertCorrectResponse(err,res)
          }
+      },
+      'with the same options and multiple fields' : {
+         topic : function(){
+            var client = solr.createClient();
+            var query = client.createQuery()
+                           .q({'*' : '*'})
+                           .rows(0)
+                           .facet({
+                              field : ['title', 'description'],
+                              prefix : 'Ipa',
+                              query : 'title:Ipad',
+                              limit : 20,
+                              offset : 0,
+                              sort : 'count',
+                              mincount : 0,
+                              missing : false,
+                              method : 'fc' ,
+                           }); 
+            client.search(query,this.callback);
+         },
+         'should return a correct response without error' :function(err,res) {
+            assertCorrectResponse(err,res)
+         }
       }
    }
 }).export(module);
+
 
 // Macro
 


### PR DESCRIPTION
The facet.field parameter can be specified multiple times to indicate
multiple facet fields [1]. This patch provides support for passing an array
instead of a string on the `field` key of the `query.facet` method
options, eg:

```
query.q({'*': '*'}).facet({'on': true, 'field': ['title', 'year']});
```

as well as:

```
query.q({'*': '*'}).facet({'on': true, 'field': 'title'});
```

[1] http://wiki.apache.org/solr/SimpleFacetParameters#facet.field
