### PR TITLE
Extend createClient params with agent

### DIFF
--- a/lib/solr.js
+++ b/lib/solr.js
@@ -474,11 +474,9 @@ var updateRequest = function(params,callback){
       port : params.port,
       method : 'POST',
       headers : headers,
-      path : params.fullPath
+      path : params.fullPath,
+      agent : params.agent
    };
-   if(params.agent !== undefined){
-       options.agent = params.agent;
-   }
    
    var callbackResponse = function(res){
       var buffer = '';
@@ -531,13 +529,11 @@ var queryRequest = function(params,callback){
    var options = {
       host : params.host,
       port : params.port,
-      path : params.fullPath
+      path : params.fullPath,
+      agent : params.agent
    };
-   if(params.agent !== undefined){
-      options.agent = params.agent;
-   }
-
-    if(params.authorization){
+   
+   if(params.authorization){ 
       var headers = {
          'authorization' : params.authorization
       };


### PR DESCRIPTION
One can pass a `new http.Agent` or `false` as fith argument to `createClient` to to overwrite the default
`globalAgent` used by `http.request` in `queryRequest` and `updateRequest`.
