### PR TITLE
Added 'spell' method to allow spellcheck with search

### DIFF
--- a/lib/solr.js
+++ b/lib/solr.js
@@ -409,6 +409,34 @@ Client.prototype.search = function(query,callback){
 }
 
 /**
+ * Search documents matching the `query`
+ * 
+ * Spellcheck is also enabled.
+ *
+ * @param {Query|String} query
+ * @param {Function} callback(err,obj) - a function executed when the Solr server responds or an error occurs
+ * @param {Error} callback().err
+ * @param {Object} callback().obj - JSON response sent by the Solr server deserialized
+ *
+ * @return {Client}
+ * @api public
+ */
+
+Client.prototype.spell = function(query,callback){
+   var self = this;
+   // Allow to be more flexible allow query to be a string and not only a Query object
+   var parameters = query.build ? query.build() : query;
+   this.options.fullPath = [this.options.path,this.options.core,'spell?' + parameters + '&wt=json']
+                              .filter(function(element){
+                                 if(element) return true;
+                                 return false;
+                              })
+                              .join('/'); ;
+   queryRequest(this.options,callback);
+   return self;
+}
+
+/**
  * Create an instance of `Query`
  *
  * @return {Query}


### PR DESCRIPTION
Added 'spell' method similar to 'search'. '/spell' is default solr handler with spellcheck enabled.
