### PR TITLE
[bug fix] breaking multi-byte characters

### DIFF
--- a/lib/solr.js
+++ b/lib/solr.js
@@ -510,19 +510,38 @@ var updateRequest = function(params,callback){
    }
 
    var callbackResponse = function(res){
-      var buffer = '';
+      var buffers = [];
+      var bodyLen = 0;
       var err = null;
       res.on('data',function(chunk){
-         buffer += chunk;
+         buffers.push(chunk);
+         bodyLen += chunk.length;
       });
 
       res.on('end',function(){
+         var body = '';
+         if (buffers.length && Buffer.isBuffer(buffers[0])) {
+             var buffer = new Buffer(bodyLen);
+             var i = 0;
+             buffers.forEach (function(chunk) {
+                 chunk.copy(buffer, i, 0, chunk.length);
+                 i += chunk.length;
+             });
+             body = buffer.toString();
+         }
+         else if (buffers.length) {
+             if (buffers[0].length > 0 && buffers[0][0] === '\uFEFF') {
+                 buffers[0] = buffers[0].substring(1);
+             }
+             body = buffers.join('');
+         }
+
          if(res.statusCode !== 200){
-            err = new SolrError(res.statusCode,buffer);
+            err = new SolrError(res.statusCode,body);
             if (callback)  callback(err,null);
          }else{
             try{
-               var data = JSON.parse(buffer);
+               var data = JSON.parse(body);
             }catch(error){
                err = error;
             }finally{


### PR DESCRIPTION
breaking multi-byte character bug fix

Let me show you some code 

```
var buffer = new Buffer('планета'); // some cyrillic characters here
console.log(buffer.length);
var buf1 = new Buffer(7); // cut between 2-byte character
var buf2 = new Buffer(7);

buffer.copy(buf1, 0, 0, 7);
buffer.copy(buf2, 0, 7, 15);

var str = '';
str += buf1;
str += buf2;

console.log(str);
console.log(buffer.toString());
```

result is

```
14
пла��ета
планета
```

the same problem is exist in solr.js code line 516.
