### PR TITLE
adding query builder support

### DIFF
--- a/examples/queryBuilder.js
+++ b/examples/queryBuilder.js
@@ -1,0 +1,55 @@
+/**
+ * Query Builder example
+ */
+
+// Use `var solr = require('solr-client')` in your code
+var solr = require('./../lib/solr');
+
+
+function search(opt) {
+  var qb = new SolrQueryBuilder();
+
+  if (opt.city) qb.where('city').in(opt.city);
+  if (opt.status) qb.where('status', opt.status);
+  if (opt.age) qb.where('age').equals(opt.age);
+
+  if (opt.startDate || opt.endDate) {
+    qb.where('birthDate').between(opt.startDate, opt.endDate);
+  }
+  
+  if (opt.offset_date && opt.offset_id) {
+    qb.begin()
+        .where('birthDate').lt(opt.offset_date)
+        .or()
+        .begin()
+          .where('birthDate').equals(opt.offset_date)
+          .where('_id').lt(opt.offset_id)
+        .end()
+      .end();
+  }
+
+  if (opt.name) {
+    qb.any({ firstName: opt.name, middleName: opt.name, lastName: opt.name });
+  }
+
+
+  var client = solr.createClient();
+
+  // DixMax query
+  var query = client.createQuery()
+              .q(qb.build())
+              .dismax()
+              .qf({title_t : 0.2 , description_t : 3.3})
+              .mm(2)
+              .start(0)
+              .rows(10);
+
+  client.search(query, function (err,obj) {
+     if(err) {
+      console.log(err);
+     } else {
+      console.log(obj);
+     }
+  });
+}
+

--- a/examples/queryBuilder.js
+++ b/examples/queryBuilder.js
@@ -4,10 +4,11 @@
 
 // Use `var solr = require('solr-client')` in your code
 var solr = require('./../lib/solr');
+var QueryBuilder = require('./../lib/query-builder');
 
 
 function search(opt) {
-  var qb = new SolrQueryBuilder();
+  var qb = new QueryBuilder();
 
   if (opt.city) qb.where('city').in(opt.city);
   if (opt.status) qb.where('status', opt.status);

--- a/lib/query-builder.js
+++ b/lib/query-builder.js
@@ -1,0 +1,116 @@
+var QueryBuilder = module.exports = function () {
+  this.query = [];
+};
+
+QueryBuilder.prototype.where = function (field, val) {
+  var prefix = '';
+
+  if (!this._ignoreNextWherePrefix && this.query.length) {
+    prefix =  opt.operator || 'AND ';
+  }
+
+  delete this._ignoreNextWherePrefix;
+
+  this._buildingWhere = true;
+
+  this.query.push(prefix + field + ':');
+
+  if (val) this.equals(val);
+
+  return this;
+};
+
+QueryBuilder.prototype._ensureIsBuildingWhere = function (method) {
+  if (!this._buildingWhere) {
+    var msg = method + '() must be used after where() when called with these arguments';
+    throw new Error(msg);
+  }
+};
+
+QueryBuilder.prototype.equals = function equals (val) {
+  this._ensureIsBuildingWhere('equals');
+
+  val = typeof val === 'string' ? quote(val) : val;
+  this.query.push(val);
+  this._buildingWhere = false;  return this;
+};
+
+QueryBuilder.prototype.in = function equals (values, separator) {
+  this._ensureIsBuildingWhere('in');
+
+  if (!Array.isArray(values)) values = values.split(separator || ',');
+
+  
+  values = values.map(function (val) {
+    return typeof val === 'string' ? quote(val) : val;
+  });
+
+  this.query.push('(' + values.join(' ') + ')');
+
+  this._buildingWhere = false;  
+  return this;
+};
+
+QueryBuilder.prototype.begin = function equals () {
+  this._ignoreNextWherePrefix = true;
+  this.query.push('(');
+  return this;
+};
+
+QueryBuilder.prototype.end = function equals () {
+  this.query.push(')');
+  return this;
+};
+
+QueryBuilder.prototype.or = function equals () {
+  this._ignoreNextWherePrefix = true;
+  this.query.push(' OR ');
+  return this;
+};
+
+QueryBuilder.prototype.any = function equals (conditions) {
+  this.begin();
+
+  var first = true;
+  for (var field in conditions) {
+    if (first) first = false; else this.or();
+
+    this.where(field).equals(conditions[field]);
+  }
+
+  this.end();
+
+  return this;
+};
+
+QueryBuilder.prototype.between = function equals (start, end, method) {
+  this._ensureIsBuildingWhere('between' || method);
+
+  if (arguments.length !== 2) throw new Error('method between() must receive 2 arguments');
+
+  if (!start) start = '*';
+  if (!end) end = '*';
+
+  this.query.push('[' + start + ' TO ' + end + ']');
+
+  this._buildingWhere = false;  
+  return this;
+};
+
+QueryBuilder.prototype.lt = function equals (val) {
+  return this.between(null, val);
+};
+
+QueryBuilder.prototype.gt = function equals (val) {
+  return this.between(val, null);
+};
+
+QueryBuilder.prototype.build = function () {
+  var q = this.query ? this.query.join(' ') : '*:*';
+  console.log(q);
+  return q;
+};
+
+function quote (value) {
+  return '"' + value + '"';
+}

--- a/lib/query-builder.js
+++ b/lib/query-builder.js
@@ -2,11 +2,11 @@ var QueryBuilder = module.exports = function () {
   this.query = [];
 };
 
-QueryBuilder.prototype.where = function (field, val) {
+QueryBuilder.prototype.where = function (field, val, opt) {
   var prefix = '';
 
   if (!this._ignoreNextWherePrefix && this.query.length) {
-    prefix =  opt.operator || 'AND ';
+    prefix =  (opt && opt.operator) || 'AND ';
   }
 
   delete this._ignoreNextWherePrefix;
@@ -27,10 +27,13 @@ QueryBuilder.prototype._ensureIsBuildingWhere = function (method) {
   }
 };
 
-QueryBuilder.prototype.equals = function equals (val) {
+QueryBuilder.prototype.equals = function equals (val, opt) {
   this._ensureIsBuildingWhere('equals');
 
-  val = typeof val === 'string' ? quote(val) : val;
+  if (typeof val === 'string'){
+    if (opt && opt.contains) val = '*' + val + '*';
+    val = quote(val);
+  }
   this.query.push(val);
   this._buildingWhere = false;  return this;
 };
@@ -40,14 +43,14 @@ QueryBuilder.prototype.in = function equals (values, separator) {
 
   if (!Array.isArray(values)) values = values.split(separator || ',');
 
-  
+
   values = values.map(function (val) {
     return typeof val === 'string' ? quote(val) : val;
   });
 
   this.query.push('(' + values.join(' ') + ')');
 
-  this._buildingWhere = false;  
+  this._buildingWhere = false;
   return this;
 };
 
@@ -68,14 +71,14 @@ QueryBuilder.prototype.or = function equals () {
   return this;
 };
 
-QueryBuilder.prototype.any = function equals (conditions) {
+QueryBuilder.prototype.any = function equals (conditions, opt) {
   this.begin();
 
   var first = true;
   for (var field in conditions) {
     if (first) first = false; else this.or();
 
-    this.where(field).equals(conditions[field]);
+    this.where(field).equals(conditions[field], opt);
   }
 
   this.end();
@@ -93,7 +96,7 @@ QueryBuilder.prototype.between = function equals (start, end, method) {
 
   this.query.push('[' + start + ' TO ' + end + ']');
 
-  this._buildingWhere = false;  
+  this._buildingWhere = false;
   return this;
 };
 
@@ -106,9 +109,7 @@ QueryBuilder.prototype.gt = function equals (val) {
 };
 
 QueryBuilder.prototype.build = function () {
-  var q = this.query ? this.query.join(' ') : '*:*';
-  console.log(q);
-  return q;
+  return this.query.length ? this.query.join(' ') : '*:*';
 };
 
 function quote (value) {


### PR DESCRIPTION
Specific query builder support for the "q" parameter.

I have included support for:
- where
- equals
- in
- blocks - "(" and ")"
- or
- any
- between
- less than - lt
- greater than - gt

Example:
```js
var qb = new QueryBuilder();

if (opt.city) qb.where('city').in(opt.city);
if (opt.status) qb.where('status', opt.status);
if (opt.age) qb.where('age').equals(opt.age);

if (opt.startDate || opt.endDate) {
  qb.where('birthDate').between(opt.startDate, opt.endDate);
}

if (opt.offset_date && opt.offset_id) {
  qb.begin()
      .where('birthDate').lt(opt.offset_date)
      .or()
      .begin()
        .where('birthDate').equals(opt.offset_date)
        .where('_id').lt(opt.offset_id)
      .end()
    .end();
}

if (opt.name) {
  qb.any({ 
    firstName: opt.name, 
    middleName: opt.name, 
    lastName: opt.name 
  }, { contains: true });
}

var client = solr.createClient();

var query = client.createQuery()
            .q(qb.build())
            .start(0)
            .rows(10);
```