### PR TITLE
Add support for Result Grouping / Field Collapsing

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -287,6 +287,7 @@ Query.prototype.groupBy = function(field){
  * @param {Object} options
  * @param {Boolean} [options.on=true] - if false, turn off result grouping, otherwise turn on.
  * @param {String|Array} options.field - Group based on the unique values of a field.
+ * @param {String|Array} options.query - Return a single group of documents that also match the given query.
  * @param {Number} [options.limit=1] - The number of results (documents) to return for each group. Solr's default value is 1.
  * @param {Number} options.offset - The offset into the document list of each group.
  * @param {String} [options.sort="score desc"] - How to sort documents within a single group. Defaults to the same value as the sort parameter.
@@ -315,6 +316,14 @@ Query.prototype.group = function(options){
         self.parameters.push('group.field=' + field);
       });
    }
+   if( options.query ){
+      if(!Array.isArray(options.query)){
+        options.query = [options.query];
+      }
+      options.query.forEach(function(query){
+        self.parameters.push('group.query=' + encodeURIComponent(query));
+      });
+   }   
    if( options.limit !== undefined){
       this.parameters.push('group.limit=' + options.limit);
    }


### PR DESCRIPTION
Add 'group.query' in grouping results.

Reference: http://wiki.apache.org/solr/FieldCollapsing
