### PR TITLE
Merge/squash between upstream/v0.3.x and origin/v0.3.x-patch39 closes #39

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -141,6 +141,23 @@ Query.prototype.rows = function(rows){
 }
 
 /**
+ * Request to use cursorMarks for deep-paging as explained in http://heliosearch.org/solr/paging-and-deep-paging/
+ * Note that usage of a cursor requires a sort containing a uniqueKey field tie breaker
+ *
+ * @param {String} mark - The mark to use, defaults to "*" to request a new cursor in the first request
+ *
+ * @return {Query}
+ * @api public
+ */
+Query.prototype.cursorMark = function(mark){
+   var self = this;
+   mark = mark || "*";
+   var parameter = 'cursorMark=' + mark ;
+   this.parameters.push(parameter);
+   return self;
+}
+
+/**
  * Sort a result in descending or ascending order based on one or more fields.
  *
  * @param {Object} options -

--- a/test/core-query-test.js
+++ b/test/core-query-test.js
@@ -1,1 +1,186 @@
-//TODO support http://wiki.apache.org/solr/CommonQueryParameters
+// Testing support http://wiki.apache.org/solr/CommonQueryParameters
+/**
+ * Modules dependencies
+ */
+
+var mocha = require('mocha'),
+	figc = require('figc'),
+	assert = require('chai').assert,
+	libPath = process.env['SOLR_CLIENT_COV'] ? '../lib-cov' : '../lib',
+	solr = require( libPath + '/solr'),
+	sassert = require('./sassert');
+
+// Test suite
+var config = figc(__dirname + '/config.json');
+var client = solr.createClient(config.client);
+var basePath = [config.client.path, config.client.core].join('/').replace(/\/$/,"");
+
+describe('Client#createQuery',function(){
+
+	describe('query() with various query options',function(){
+		it('basic query with multiple fields',function(done){
+
+			var query = client.createQuery()
+				.q({"title": "name", "author" : "me"}).debugQuery();
+
+			client.search(query, function(err, data){
+				sassert.ok(err, data);
+				assert.deepEqual(data.responseHeader.params, 
+						{ debugQuery: "true"
+            , q: "title:name AND author:me"
+            , wt: 'json'});
+				done();
+			});
+    });
+
+		it('query sorted',function(done){
+
+			var query = client.createQuery()
+				.q("*:*").sort({ "author":"asc", "category":"desc"}).debugQuery();
+
+			client.search(query, function(err, data){
+				sassert.ok(err, data);
+				assert.deepEqual(data.responseHeader.params, 
+						{ debugQuery: "true"
+            , q: "*:*", sort: "author asc,category desc"
+            , wt: 'json'});
+				done();
+			});
+		});
+
+		it('query with paging',function(done){
+
+			var query = client.createQuery()
+        .q("*:*").start(21).rows(20).debugQuery();
+
+			client.search(query, function(err, data){
+				sassert.ok(err, data);
+				assert.deepEqual(data.responseHeader.params, 
+						{ debugQuery: "true"
+            , q: "*:*", start: "21", rows: "20"
+            , wt: 'json'});
+				done();
+			});
+		});
+
+		it('query paged with cursorMark',function(done){
+
+			var query = client.createQuery()
+				.q("*:*").start(0).sort({"id": "asc"}).cursorMark().debugQuery();
+
+			client.search(query, function(err, data){
+				sassert.ok(err, data);
+				assert.deepEqual(data.responseHeader.params, 
+						{ debugQuery: "true"
+            , q: "*:*", start: "0", sort: "id asc", cursorMark: "*"
+            , wt: 'json'});
+				done();
+			});
+		});
+
+		it('custom parameter setting - allows for any Filterquery(fq)',function(done){
+
+			var query = client.createQuery()
+				.q("*:*").set("fq=sqrt(id)").debugQuery();
+
+			client.search(query, function(err, data){
+				sassert.ok(err, data);
+				assert.deepEqual(data.responseHeader.params, 
+						{ debugQuery: "true"
+            , q: "*:*", fq: "sqrt(id)"
+            , wt: 'json'});
+				done();
+			});
+		});
+
+		it('listing fields with fl',function(done){
+
+			var query = client.createQuery()
+				.q("*:*").fl(['id','title*', 'score']).debugQuery();
+
+			client.search(query, function(err, data){
+				sassert.ok(err, data);
+				assert.deepEqual(data.responseHeader.params, 
+						{ debugQuery: "true"
+            , q: "*:*", fl: "id,title*,score"
+            , wt: 'json'});
+				done();
+			});
+		});
+
+		it('query with deftype',function(done){
+
+			var query = client.createQuery()
+				.q("*:*").defType("lucene").debugQuery();
+
+			client.search(query, function(err, data){
+				sassert.ok(err, data);
+				assert.deepEqual(data.responseHeader.params, 
+						{ debugQuery: "true"
+            , q: "*:*", defType: "lucene"
+            , wt: 'json'});
+				done();
+			});
+		});
+
+		it('query with time-allowed',function(done){
+
+			var query = client.createQuery()
+				.q("*:*").timeout(1000).debugQuery();
+
+			client.search(query, function(err, data){
+				sassert.ok(err, data);
+				assert.deepEqual(data.responseHeader.params, 
+						{ debugQuery: "true"
+            , q: "*:*", timeAllowed: "1000"
+            , wt: 'json'});
+				done();
+			});
+		});
+
+		it('q.op - Default query-operator',function(done){
+
+			var query = client.createQuery()
+				.q("author:ali remy marc").qop("OR").debugQuery();
+
+			client.search(query, function(err, data){
+				sassert.ok(err, data);
+				assert.deepEqual(data.responseHeader.params, 
+						{ debugQuery: "true"
+            , q: "author:ali remy marc", "q.op": "OR"
+            , wt: 'json'});
+				done();
+			});
+		});
+
+		it('query with range-filter',function(done){
+
+			var query = client.createQuery()
+				.q("*:*").rangeFilter({field: 'id', start: 100, end: 200}).debugQuery();
+
+			client.search(query, function(err, data){
+				sassert.ok(err, data);
+				assert.deepEqual(data.responseHeader.params, 
+						{ debugQuery: "true"
+            , q: "*:*", fq:"id:[100 TO 200]"
+            , wt: 'json'});
+				done();
+			});
+		});
+
+		it('query with match-filter',function(done){
+
+			var query = client.createQuery()
+				.q("*:*").matchFilter('id', "19700506.173.85").debugQuery();
+
+			client.search(query, function(err, data){
+				sassert.ok(err, data);
+				assert.deepEqual(data.responseHeader.params, 
+						{ debugQuery: "true"
+            , q: "*:*", fq:"id:19700506.173.85"
+            , wt: 'json'});
+				done();
+			});
+		});
+	});
+});

--- a/test/facet-query-test.js
+++ b/test/facet-query-test.js
@@ -20,12 +20,45 @@ var client = solr.createClient(config.client);
 var basePath = [config.client.path, config.client.core].join('/').replace(/\/$/,"");
 
 describe('Client#createQuery()',function(){
-	describe('.facet({field : "category_t"}).q({title_t : "test"})',function(){
-		it('should create a facet on the field "category_t"',function(done){
+	describe('.facet(options)',function(){
+		it('should create a facet for multiple date/range fields',function(done){
+			var date = new Date().getTime();
+			var facetOptions = {
+									"on": true
+								,	"query": "query"
+								,	"field": "author"
+								,	"prefix": "prefix"
+								,	"sort": "field desc"
+								,	"limit": 100
+								,	"offset": 5
+								,	"mincount": 10
+								,	"missing": true
+								,	"method": "fc"
+								,	"date": [{
+											"field": "date_field"
+										,	"start": date
+										,	"end": date
+										,	"gap": "+1DAY"
+										,	"hardened": true
+										,	"other": "all"
+										,	"include": "all"
+										}]
+								,	"range": [{
+											"field": "range_field"
+										,	"start": 0.0
+										,	"end": "1000"	
+										,	"gap": "+1DAY"
+										,	"hardened": true
+										,	"other": "all"
+										,	"include": "all"
+										}]
+								,	"pivot": {
+											"fields": ["cat", "popularity"]
+										,	"mincount": 10	
+										}
+								}
 			var query = client.createQuery()
-				.facet({
-					field : 'category_t'
-				})
+				.facet(facetOptions)
 				.q({ title_t : 'test'})
 				.debugQuery();
 			client.search(query,function(err,data){
@@ -36,7 +69,79 @@ describe('Client#createQuery()',function(){
 						wt: 'json',
 						debugQuery: 'true',
 						q: 'title_t:test',
-						'facet.field': 'category_t' 
+						"facet.field": 'author',
+ 						"facet.limit": "100",
+						"facet.method": "fc",
+						"facet.mincount": "10",
+						"facet.missing": "true",
+						"facet.offset": "5",
+						"facet.prefix": "prefix",
+						"facet.query": "query",
+						"facet.sort": "field\\ desc"
+					}
+        		);
+				assert.equal(data.debug.QParser,'LuceneQParser');
+				done();
+			});
+		});
+
+		it('should create a facet for single date/range fields',function(done){
+			var date = new Date().getTime();
+			var facetOptions = {
+									"on": true
+								,	"query": "query"
+								,	"field": "author"
+								,	"prefix": "prefix"
+								,	"sort": "field desc"
+								,	"limit": 100
+								,	"offset": 5
+								,	"mincount": 10
+								,	"missing": true
+								,	"method": "fc"
+								,	"date": {
+											"field": "date_field"
+										,	"start": date
+										,	"end": date
+										,	"gap": "+1DAY"
+										,	"hardened": true
+										,	"other": "all"
+										,	"include": "all"
+										}
+								,	"range": {
+											"field": "range_field"
+										,	"start": 0.0
+										,	"end": "1000"	
+										,	"gap": "+1DAY"
+										,	"hardened": true
+										,	"other": "all"
+										,	"include": "all"
+										}
+								,	"pivot": {
+											"fields": "cat"
+										,	"mincount": 10	
+										}
+								}
+			var query = client.createQuery()
+				.facet(facetOptions)
+				.q({ title_t : 'test'})
+				.debugQuery();
+			client.search(query,function(err,data){
+				sassert.ok(err,data);
+				assert.deepEqual(data.responseHeader.params,
+					{
+						facet: 'true',
+						wt: 'json',
+						debugQuery: 'true',
+						q: 'title_t:test',
+						"facet.field": 'author',
+ 						"facet.limit": "100",
+						"facet.method": "fc",
+						"facet.mincount": "10",
+						"facet.missing": "true",
+						"facet.offset": "5",
+						"facet.prefix": "prefix",
+						"facet.query": "query",
+						"facet.sort": "field\\ desc"
 					}
         		);
 				assert.equal(data.debug.QParser,'LuceneQParser');

--- a/test/group-query-test.js
+++ b/test/group-query-test.js
@@ -1,1 +1,67 @@
-//TODO support http://wiki.apache.org/solr/FieldCollapsing?highlight=%28field%29%7C%28collapsing%29
+//Testing support http://wiki.apache.org/solr/FieldCollapsing?highlight=%28field%29%7C%28collapsing%29
+/**
+ * Modules dependencies
+ */
+
+var mocha = require('mocha'),
+	figc = require('figc'),
+	assert = require('chai').assert,
+	libPath = process.env['SOLR_CLIENT_COV'] ? '../lib-cov' : '../lib',
+	solr = require( libPath + '/solr'),
+	sassert = require('./sassert');
+
+// Test suite
+var config = figc(__dirname + '/config.json');
+var client = solr.createClient(config.client);
+var basePath = [config.client.path, config.client.core].join('/').replace(/\/$/,"");
+
+describe('Client#createQuery',function(){
+
+	describe('.groupBy(field), callback)',function(){
+		it('should create a group by query',function(done){
+			var query = client.createQuery()
+				.q('test')
+				.groupBy('title_t')
+				.debugQuery();
+			client.search(query, function(err, data){
+				sassert.ok(err, data);
+				assert(data.responseHeader.params.group);
+				assert.equal('title_t', data.responseHeader.params['group.field']);
+				done();
+			});
+		});
+	});
+
+	describe('#group(options), callback)',function(){
+		it('should create a group query',function(done){
+			var options = {
+								"on": true
+							,	"field": "title_t"
+							, 	"func": "test"
+							,	"rows": 11
+							,	"start": 1
+							,	"limit": 15
+							,	"offset": 8
+							,	"sort": "score desc"
+							,	"format": "simple"
+							,	"main":	true
+							,	"ngroups": true
+							,	"truncate": true
+							,	"facet": true
+							,	"cache": 50
+						};
+
+			var query = client.createQuery()
+				.group(options);
+
+			client.search(query, function(err, data){
+				sassert.ok(err, data);
+				assert.deepEqual(data.responseHeader.params, 
+						{'group.format':'simple','group.ngroups':'true','group.limit':'15','group.truncate':'true',
+						'group.field':'title_t','group.main':'true',group:'true','group.sort':'score desc',
+						'group.cache.percent':'50','group.offset':'8',wt:'json'});
+				done();
+			});
+		});
+	});
+});

--- a/test/mlt-query-test.js
+++ b/test/mlt-query-test.js
@@ -1,1 +1,63 @@
-//TODO support http://wiki.apache.org/solr/MoreLikeThis
+// Testing support http://wiki.apache.org/solr/MoreLikeThis
+/**
+ * Modules dependencies
+ */
+
+var mocha = require('mocha'),
+	figc = require('figc'),
+	assert = require('chai').assert,
+	libPath = process.env['SOLR_CLIENT_COV'] ? '../lib-cov' : '../lib',
+	solr = require( libPath + '/solr'),
+	sassert = require('./sassert');
+
+// Test suite
+var config = figc(__dirname + '/config.json');
+var client = solr.createClient(config.client);
+var basePath = [config.client.path, config.client.core].join('/').replace(/\/$/,"");
+
+
+describe('Client#createQuery',function(){
+	describe('#mlt(options), callback)',function(){
+		it('should create a MoreLikeThis query',function(done){
+			var options = {
+								"on": true
+							,	"fl": ['content', 'title']
+							,	"count": 15
+							,	"mintf": 0
+							,	"mindf": 0
+							,	"minwl": 0
+							,	"maxwl": 1500
+							,	"maxqt": 1500
+							,	"maxntp": 1500
+							,	"boost": true
+							,	"qf": 1
+						};
+
+			var query = client.createQuery()
+				.mlt(options)
+				.q({'title_t': 'test'})
+				.debugQuery();
+
+			client.search(query, function(err, data){
+				sassert.ok(err, data);
+				assert.deepEqual(data.responseHeader.params, 
+						{ 	'mlt.minwl': '0',
+					        'mlt.fl': 'content,title',
+					        'mlt.boost': 'true',
+					        'mlt.mintf': '0',
+					        'mlt.qf': '1',
+					        mlt: 'true',
+					        'mlt.maxwl': '1500',
+					        'mlt.maxntp': '1500',
+					        'mlt.maxqt': '1500',
+					        wt: 'json',
+					        'mlt.mindf': '0',
+					        'mlt.count': '15',
+ 					        "debugQuery": "true",
+					        q: "title_t:test"
+					    });
+				done();
+			});
+		});
+	});
+});


### PR DESCRIPTION
This introduces a number of new tests that were still missing and were announced or discussed in #39

This includes the test (and implementation) for the solr core feature of deep paging through "cursormark" as described in #89

Conflicts:
    package.json
    test/core-query-test.js
    test/group-query-test.js
    test/mlt-query-test.js
