### PR TITLE
Added mlt alongside search and spell

### DIFF
--- a/lib/solr.js
+++ b/lib/solr.js
@@ -437,6 +437,32 @@ Client.prototype.spell = function(query,callback){
 }
 
 /**
+ * More like this matching the `query`
+ *
+ * @param {Query|String} more like this query
+ * @param {Function} callback(err,obj) - a function executed when the Solr server responds or an error occurs
+ * @param {Error} callback().err
+ * @param {Object} callback().obj - JSON response sent by the Solr server deserialized
+ *
+ * @return {Client}
+ * @api public
+ */
+
+Client.prototype.mlt = function(query,callback){
+   var self = this;
+   // Allow to be more flexible allow query to be a string and not only a Query object
+   var parameters = query.build ? query.build() : query;
+   this.options.fullPath = [this.options.path,this.options.core,'mlt?' + parameters + '&wt=json']
+                              .filter(function(element){
+                                 if(element) return true;
+                                 return false;
+                              })
+                              .join('/'); ;
+   queryRequest(this.options,callback);
+   return self;
+}
+
+/**
  * Create an instance of `Query`
  *
  * @return {Query}


### PR DESCRIPTION
Added MLT function to enable a direct more like this search instead of a normal search with MLT components in the result set.  It is a simple duplicate of 'spell' and 'search', did not feel appropriate to refactor these three methods into something more common as it would have broken any external API.
