### PR TITLE
Added atomicUpdate() to partially update documents.

### DIFF
--- a/examples/atomicUpdate.js
+++ b/examples/atomicUpdate.js
@@ -1,0 +1,43 @@
+/**
+ * Partially update a document into the Solr index.
+ */
+
+// Use `var solr = require('solr-client')` in your code
+var solr = require('./../lib/solr');
+
+// Create a client
+var client = solr.createClient();
+
+// Switch on "auto commit", by default `client.autoCommit = false`
+client.autoCommit = true;
+
+var doc = {
+     id : 12357,
+     title_t : "Original Title"
+     small_l : 12,
+     description_t : "Some Description"
+ }
+
+// Add documents
+client.add(doc,function(err,obj){
+   if(err){
+      console.log(err);
+   }else{
+      console.log(obj);
+   }
+});
+
+var updateDoc = {
+     id : 12357,
+     title_t : { "set" : "Modified Title" },
+     small_l : { "inc" : 2 }
+ }
+
+// Add documents
+client.atomicUpdate(doc,function(err,obj){
+   if(err){
+      console.log(err);
+   }else{
+      console.log(obj);
+   }
+});

--- a/lib/solr.js
+++ b/lib/solr.js
@@ -138,6 +138,23 @@ Client.prototype.add = function(docs,options,callback){
    return this.update(docs,options,callback);
 }
 
+
+/**
+ * Updates a document or a list of documents Solr 4.0+
+ * This function is a clone of add and it was added to give more clarity on the availability of atomic updates.
+ *
+ * @param {Object|Array} doc - document or list of documents to be updated into the Solr database (set, inc, add)
+ * @param {Object} [options] -
+ * @param {Function} callback(err,obj) - a function executed when the Solr server responds or an error occurs
+ * @param {Error} callback().err
+ * @param {Object} callback().obj - JSON response sent by the Solr server deserialized
+ *
+ * @return {http.ClientRequest}
+ * @api public
+ */
+
+Client.prototype.atomicUpdate = Client.prototype.add;
+
 /**
  * Get a document by id or a list of documents by ids using the Real-time-get feature
  *  in SOLR4 (https://wiki.apache.org/solr/RealTimeGet)

--- a/test/update-test.js
+++ b/test/update-test.js
@@ -1,0 +1,72 @@
+/**
+ * Modules dependencies
+ */
+
+var mocha = require('mocha'),
+	figc = require('figc'),
+	assert = require('chai').assert,
+	libPath = process.env['SOLR_CLIENT_COV'] ? '../lib-cov' : '../lib',
+	solr = require( libPath + '/solr'),
+	sassert = require('./sassert');
+
+// Test suite
+var config = figc(__dirname + '/config.json');
+var client = solr.createClient(config.client);
+var basePath = [config.client.path, config.client.core].join('/').replace(/\/$/,"");
+
+/**
+atomicUpdate is just an override of update like add and from the Solr point of view idiomatically correct.
+**/
+describe('Client',function(){
+	describe('#Atomic update({ id : 1, title_t : "Modified title"},callback)',function(){
+
+        var doc_id = 'RandomId-' + Math.floor(Math.random() * 1000000);
+        var small = '97';             // same showing string-conversion is not at fault
+        var doc = {
+            id : doc_id,
+            small_l : small,
+            title_t : 'Original title'
+        };
+        var options = {
+          commit : true // force commit, not really needed, but it ensures full process cycle at solr side
+        };
+
+		it('should add one document',function(done){
+			client.add(doc, options, function(err,data){
+				sassert.ok(err,data);
+				done();
+			});
+		});
+
+		it('should partially update one document',function(done){
+			var updatedDoc = {
+				id : doc_id,
+				title_t : {'set':'Modified title'}
+			};
+			client.atomicUpdate(updatedDoc, function(err,data){
+				sassert.ok(err,data);
+				done();
+			});
+		});
+
+		it('should have updated the document',function(done){
+ 			client.realTimeGet(doc_id,{omitHeader: false}, function(err,data){
+                sassert.ok(err,data);
+                assert.equal(data.response.numFound, 1, 'Updated document should be retrieved in real-time get.');
+                var retrieved = data.response.docs[0];
+                assert.equal(retrieved.title_t, "Modified title", 'Updated document should have a modified title.');
+                assert.equal(retrieved.id, doc_id, 'Updated document should have the same id');
+                assert.equal(retrieved.small_l, small, 'Updated document should have the same old small value');
+                done();
+            });
+		});
+
+ 		it('should be able to delete it',function(done){
+            client.deleteByID(doc_id, options, function(err,data){
+                sassert.ok(err,data);
+                done();
+            });
+        });
+
+	});
+});


### PR DESCRIPTION
This is a trivial new function to override what effectively this.update does. It works the same way as cliend.add and it uses the same set, add, inc syntax from [Solr 4.0+](https://wiki.apache.org/solr/UpdateJSON#Solr_4.0_Example)