### PR TITLE
Change search to use POST instead of GET to accommodate long queries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-before_script: curl -sSL https://raw.githubusercontent.com/moliware/travis-solr/master/travis-solr.sh | SOLR_VERSION=4.9.1 bash
+before_script: curl -sSL https://raw.githubusercontent.com/moliware/travis-solr/797595342d3b597d373c635329fad6bcf0378e3f/travis-solr.sh | SOLR_VERSION=4.9.1 bash
 language: node_js
 node_js:
   - 0.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-before_script: curl https://raw.githubusercontent.com/moliware/travis-solr/master/travis-solr.sh | SOLR_VERSION=4.9.0 bash
+before_script: curl -sSL https://raw.githubusercontent.com/moliware/travis-solr/master/travis-solr.sh | SOLR_VERSION=4.9.1 bash
 language: node_js
 node_js:
   - 0.8

--- a/README.md
+++ b/README.md
@@ -97,9 +97,29 @@ client.options.bigint = true;
 
 Post an issue if you have troubles migrating to v0.4.0.
 
+##Migration between 0.4.x and 0.5.x
+
+The only breaking change introduced in `0.5.x` is introduced in this commit [3cbc7fc6cf631f019a4626913c0a4b616092133b](https://github.com/lbdremy/solr-node-client/commit/3cbc7fc6cf631f019a4626913c0a4b616092133b) which remove escaping of the Solr special characters in some of the methods of the `Query` class i.e in `Query#rangeFilter`, `Query#matchFilter`, `Query#group`, `Query#facet`, `Query#mlt` if you were relying on this behavior just wrap the arguments you passed to those methods into the [`solr.escapeSpecialChars(arg)`](https://github.com/lbdremy/solr-node-client/blob/master/lib/solr.js#L605) method.
+
+For example, for some weird reason you wanted to escape the special char `*`, don't ask me ;)
+
+```js
+var query = client.createQuery();
+query.q({ '*' : '*' }).rangeFilter({ field : 'id', start : 100, end : '*'})
+```
+
+You still can:
+
+```js
+var query = client.createQuery();
+query.q({ '*' : '*' }).rangeFilter({ field : 'id', start : 100, end : solr.escapeSpecialChars('*')})
+```
+
+Post an issue if you have troubles migrating to v0.5.0.
+
 ##Roadmap
 
-###v0.3.x
+###v0.3.x - v0.x.x
 
 - Test suite with mocha and chai instead of vows
 - Implement all features available in Solr 4 (SolrCloud API in particular)

--- a/lib/query.js
+++ b/lib/query.js
@@ -201,7 +201,7 @@ Query.prototype.rangeFilter = function(options){
       var filters = options.map(function(option){
          var key = option.field;
          var filter = {};
-         filter[key] = '[' + format.escapeAndEncode(option.start) + '%20TO%20' + format.escapeAndEncode(option.end) + ']';
+         filter[key] = '[' + encodeURIComponent(option.start) + '%20TO%20' + encodeURIComponent(option.end) + ']';
          return format.stringify(filter, '',':');
       });
       parameter += filters.join('%20AND%20');
@@ -209,7 +209,7 @@ Query.prototype.rangeFilter = function(options){
    }else{
       var key = options.field;
       var filter = {};
-      filter[key] = '[' + format.escapeAndEncode(options.start) + '%20TO%20' + format.escapeAndEncode(options.end) + ']';
+      filter[key] = '[' + encodeURIComponent(options.start) + '%20TO%20' + encodeURIComponent(options.end) + ']';
       parameter += format.stringify(filter, '',':');
    }
    this.parameters.push(parameter);
@@ -234,7 +234,7 @@ Query.prototype.matchFilter = function(field,value){
    var self = this;
    value = format.dateISOify(value);
    var parameter = 'fq=';
-   parameter += field + ':' + format.escapeAndEncode(value);
+   parameter += field + ':' + encodeURIComponent(value);
    this.parameters.push(parameter);
    return self;
 }
@@ -341,7 +341,7 @@ Query.prototype.group = function(options){
       this.parameters.push('group.sort=' + encodeURIComponent(options.sort));
    }
    if( options.format ){
-      this.parameters.push('group.format=' + format.escapeAndEncode(options.format));
+      this.parameters.push('group.format=' + encodeURIComponent(options.format));
    }
    if( options.main !== undefined){
       this.parameters.push('group.main=' + options.main);
@@ -395,10 +395,10 @@ Query.prototype.facet = function(options){
       }
    }
    if(options.prefix){
-      this.parameters.push('facet.prefix=' + format.escapeAndEncode(options.prefix))
+      this.parameters.push('facet.prefix=' + encodeURIComponent(options.prefix))
    }
    if(options.sort){
-      this.parameters.push('facet.sort=' + format.escapeAndEncode(options.sort))
+      this.parameters.push('facet.sort=' + encodeURIComponent(options.sort))
    }
    if(options.limit !== undefined){
       this.parameters.push('facet.limit=' + options.limit);
@@ -447,7 +447,7 @@ Query.prototype.mlt = function(options){
   }
   if(options.fl){
     if(options.fl instanceof Array) options.fl = options.fl.join(',');
-    this.parameters.push('mlt.fl=' + format.escapeAndEncode(options.fl))
+    this.parameters.push('mlt.fl=' + encodeURIComponent(options.fl))
   }
   if(options.count !== undefined){
     this.parameters.push('mlt.count=' + options.count)
@@ -477,7 +477,7 @@ Query.prototype.mlt = function(options){
     if( typeof options.qf === 'object'){
       var parameter = querystring.stringify(options.qf, '%20' , '^');;
     }else{
-      var parameter = format.escapeAndEncode(options.qf);
+      var parameter = encodeURIComponent(options.qf);
     }
     this.parameters.push('mlt.qf=' + parameter);
   }

--- a/lib/solr.js
+++ b/lib/solr.js
@@ -11,15 +11,15 @@
  */
 
 var http = require('http'),
-   https = require('https'),
-   Query = require('./query'),
-   querystring = require('querystring'),
-   format = require('./utils/format'),
-   SolrError = require('./error/solr-error'),
-   JSONStream = require('JSONStream'),
-   duplexer = require('duplexer'),
-   request = require('request'),
-   JSONbig = require('json-bigint');
+    https = require('https'),
+    Query = require('./query'),
+    querystring = require('querystring'),
+    format = require('./utils/format'),
+    SolrError = require('./error/solr-error'),
+    JSONStream = require('JSONStream'),
+    duplexer = require('duplexer'),
+    request = require('request'),
+    JSONbig = require('json-bigint');
 
 /**
  * Expose `createClient()`.
@@ -44,7 +44,7 @@ exports.createClient = createClient;
  */
 
 function createClient(host, port, core, path, agent, secure, bigint){
-  var options = (typeof host === 'object') ? host : {
+   var options = (typeof host === 'object') ? host : {
       host : host,
       port : port,
       core : core,
@@ -53,7 +53,7 @@ function createClient(host, port, core, path, agent, secure, bigint){
       secure : secure,
       bigint : bigint
    };
-  return new Client(options);
+   return new Client(options);
 }
 
 /**
@@ -214,10 +214,10 @@ Client.prototype.addRemoteResource = function(options,callback){
 
 Client.prototype.createAddStream = function(options){
    var path = [this.options.path,this.options.core, this.UPDATE_JSON_HANDLER + '?' + querystring.stringify(options) +'&wt=json']
-      .filter(function(element){
-         return element;
-      })
-      .join('/');
+       .filter(function(element){
+          return element;
+       })
+       .join('/');
    var headers = {
       'content-type' : 'application/json',
       'charset' : 'utf-8'
@@ -476,22 +476,23 @@ Client.prototype.update = function(data,options,callback){
 
    var json = pickJSON(this.options.bigint).stringify(data);
    var fullPath = [this.options.path,this.options.core, this.UPDATE_JSON_HANDLER + '?' + querystring.stringify(options) +'&wt=json']
-                              .filter(function(element){
-                                 return element;
-                              })
-                              .join('/');
+       .filter(function(element){
+          return element;
+       })
+       .join('/');
 
    var params = {
       host : this.options.host,
       port : this.options.port,
       fullPath : fullPath,
-      json : json,
+      data : json,
       secure : this.options.secure,
       bigint : this.options.bigint,
       authorization : this.options.authorization,
-      agent : this.options.agent
+      agent : this.options.agent,
+      contentType : 'application/json; charset=utf-8'
    };
-   return postJSON(params,callback);
+   return postDATA(params,callback);
 }
 
 /**
@@ -507,7 +508,7 @@ Client.prototype.update = function(data,options,callback){
  */
 
 Client.prototype.search = function(query,callback){
-   return this.get(this.SELECT_HANDLER, query, callback);
+   return this.post(this.SELECT_HANDLER, query, callback);
 }
 
 /**
@@ -570,10 +571,10 @@ Client.prototype.get = function(handler,query,callback){
    }
 
    var fullPath = [this.options.path,this.options.core,handler + '?' + parameters + '&wt=json']
-                              .filter(function(element){
-                                 return element;
-                              })
-                              .join('/');
+       .filter(function(element){
+          return element;
+       })
+       .join('/');
 
    var params = {
       host : this.options.host,
@@ -585,6 +586,52 @@ Client.prototype.get = function(handler,query,callback){
       agent : this.options.agent
    };
    return getJSON(params,callback);
+}
+
+/**
+ * Send an arbitrary HTTP POST request to Solr on the specified `handler` (as Solr like to call it i.e path)
+ *
+ * @param {String} handler
+ * @param {Query|Object|String} [query]
+ * @param {Function} callback(err,obj) - a function executed when the Solr server responds or an error occurs
+ * @param {Error} callback().err
+ * @param {Object} callback().obj - JSON response sent by the Solr server deserialized
+ *
+ * @return {http.ClientRequest}
+ * @api public
+ */
+
+Client.prototype.post = function(handler,query,callback){
+
+   var parameters = '';
+   if(typeof query === 'function'){
+      callback = query;
+   }else if(query instanceof Query){
+      parameters += query.build();
+   }else if(typeof query === 'object'){
+      parameters += query;
+   }else if(typeof query === 'string'){
+      parameters += query;
+   }
+
+   var fullPath = [this.options.path,this.options.core,handler]
+       .filter(function(element){
+          return element;
+       })
+       .join('/');
+
+   var params = {
+      host : this.options.host,
+      port : this.options.port,
+      fullPath : fullPath,
+      data : parameters + '&wt=json',
+      secure : this.options.secure,
+      bigint : this.options.bigint,
+      authorization : this.options.authorization,
+      agent : this.options.agent,
+      contentType: 'application/x-www-form-urlencoded'
+   };
+   return postDATA(params,callback);
 }
 
 /**
@@ -644,7 +691,7 @@ function pickJSON(bigint){
 };
 
 /**
- * HTTP POST request. Send update commands to the Solr server (commit, add, delete, optimize)
+ * HTTP POST request. Send commands to the Solr server (select, commit, add, delete, optimize, etc.)
  *
  * @param {Object} params
  * @param {String} params.host - IP address or host address of the Solr server
@@ -664,10 +711,10 @@ function pickJSON(bigint){
  * @api private
  */
 
-function postJSON(params,callback){
+function postDATA(params,callback){
    var headers = {
-      'content-type' : 'application/json; charset=utf-8',
-      'content-length':  Buffer.byteLength(params.json),
+      'content-type' : params.contentType,
+      'content-length':  Buffer.byteLength(params.data),
       'accept' : 'application/json; charset=utf-8'
    };
    if(params.authorization){
@@ -693,7 +740,7 @@ function postJSON(params,callback){
       if (callback) callback(err,null);
    });
 
-   request.write(params.json);
+   request.write(params.data);
    request.end();
 
    return request;
@@ -734,7 +781,7 @@ function getJSON(params,callback){
       options.agent = params.agent;
    }
 
-    if(params.authorization){
+   if(params.authorization){
       var headers = {
          'authorization' : params.authorization
       };

--- a/lib/solr.js
+++ b/lib/solr.js
@@ -82,7 +82,8 @@ function Client(options){
       path : options.path || '/solr',
       agent : options.agent,
       secure : options.secure || false,
-      bigint : options.bigint || false
+      bigint : options.bigint || false,
+      searchMethod: options.searchMethod || "GET"
    };
 
    // Default paths of all request handlers
@@ -508,7 +509,11 @@ Client.prototype.update = function(data,options,callback){
  */
 
 Client.prototype.search = function(query,callback){
-   return this.post(this.SELECT_HANDLER, query, callback);
+   if (this.options.searchMethod === "POST") {
+      return this.post(this.SELECT_HANDLER, query, callback);
+   } else {
+      return this.get(this.SELECT_HANDLER, query, callback);
+   }
 }
 
 /**

--- a/lib/utils/format.js
+++ b/lib/utils/format.js
@@ -132,21 +132,3 @@ function escapeSpecialChars(s){
     return '\\' + match;
   });
 }
-
-/**
- * Expose `escapeAndEncode`
- */
-
-exports.escapeAndEncode = escapeAndEncode;
-
-/**
- * Escape with `escapeSpecialChars` and encode with `encodeURIComponent`
- * @param {String} s - string to escape and encode
- *
- * @return {String}
- * @api private
- */
-
-function escapeAndEncode(s){
-  return encodeURIComponent(escapeSpecialChars(s.toString()));
-}

--- a/lib/utils/format.js
+++ b/lib/utils/format.js
@@ -128,7 +128,9 @@ function stringifyPrimitive(v) {
   */
 
 function escapeSpecialChars(s){
-  return s.replace(/([\+\-&\|!\(\)\{\}\[\]\^"~\*\?:\\\ ])/g, function(match) {
+  return s.replace(/([\+\-!\(\)\{\}\[\]\^"~\*\?:\\])/g, function(match) {
     return '\\' + match;
-  });
+  })
+  .replace(/&&/g, '\\&\\&')
+  .replace(/\|\|/g, '\\|\\|');
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "duplexer": "~0.1.1",
     "httperror": "~0.2.2",
     "json-bigint": "~0.1.3",
-    "request": "~2.42.0"
+    "request": "~2.49.0"
   },
   "devDependencies": {
     "chai": "~1.9.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "name": "solr-client",
   "main": "./main",
   "description": " A Solr client library for indexing, adding, deleting, committing, optimizing and searching documents within an Apache Solr installation (version>=3.2)",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/lbdremy/solr-node-client"

--- a/test/facet-query-test.js
+++ b/test/facet-query-test.js
@@ -77,7 +77,7 @@ describe('Client#createQuery()',function(){
 						"facet.offset": "5",
 						"facet.prefix": "prefix",
 						"facet.query": "query",
-						"facet.sort": "field\\ desc"
+						"facet.sort": "field desc"
 					}
         		);
 				assert.equal(data.debug.QParser,'LuceneQParser');
@@ -141,7 +141,7 @@ describe('Client#createQuery()',function(){
 						"facet.offset": "5",
 						"facet.prefix": "prefix",
 						"facet.query": "query",
-						"facet.sort": "field\\ desc"
+						"facet.sort": "field desc"
 					}
         		);
 				assert.equal(data.debug.QParser,'LuceneQParser');

--- a/test/search-test.js
+++ b/test/search-test.js
@@ -17,7 +17,7 @@ var basePath = [config.client.path, config.client.core].join('/').replace(/\/$/,
 
 describe('Client',function(){
 	describe('#search("q=*:*")',function(){
-		it('should find all documents',function(done){
+		it('should find all documents using GET',function(done){
 			client.search('q=*:*',function(err,data){
 				sassert.ok(err,data);
 				assert.deepEqual({ q : '*:*' , wt: 'json' },data.responseHeader.params);
@@ -26,7 +26,31 @@ describe('Client',function(){
 		});
 	});
 	describe('#search(query)',function(){
-		it('should find documents describe in the `query` instance of `Query`',function(done){
+		it('should find documents using GET described in the `query` instance of `Query`',function(done){
+			var query = client.createQuery()
+				.q({
+					'title_t' : 'test'
+				});
+			client.search(query,function(err,data){
+				sassert.ok(err,data);
+				assert.deepEqual({ q : 'title_t:test', wt: 'json' },data.responseHeader.params);
+				done();
+			});
+		});
+	});
+	describe('#search("q=*:*")',function(){
+		it('should find all documents using POST',function(done){
+			client.options.searchMethod = 'POST'
+			client.search('q=*:*',function(err,data){
+				sassert.ok(err,data);
+				assert.deepEqual({ q : '*:*' , wt: 'json' },data.responseHeader.params);
+				done();
+			});
+		});
+	});
+	describe('#search(query)',function(){
+		it('should find documents using POST, described in the `query` instance of `Query`',function(done){
+			client.options.searchMethod = 'POST'
 			var query = client.createQuery()
 				.q({
 					'title_t' : 'test'

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -12,9 +12,9 @@ var mocha = require('mocha'),
 describe('format',function(){
 	describe('.escapeSpecialChars(string)',function(){
 		it('should escape all special characters',function(){
-			var string = '+-&&||!(){}[]^"~*?:\\ ';
+			var string = '+-&&||!(){}[]^"~*?:\\';
         	var escapedString = format.escapeSpecialChars(string);
-        	assert.equal(escapedString,'\\+\\-\\&\\&\\|\\|\\!\\(\\)\\{\\}\\[\\]\\^\\"\\~\\*\\?\\:\\\\\\ ');
+        	assert.equal(escapedString,'\\+\\-\\&\\&\\|\\|\\!\\(\\)\\{\\}\\[\\]\\^\\"\\~\\*\\?\\:\\\\');
 		});
 	});
 	describe('.dateISOify()',function(){


### PR DESCRIPTION
HTTP POST for search(select) #110

The code below switches searches to use POST instead of GET, allowing for very long query strings.
It should be trivial to add a switch in search that would allow choosing either option based on either query length or configuration.  
