### PR TITLE
Search Solr using POST instead of GET

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ docs/out
 coverage.html
 lib-cov
 report
+.idea

--- a/lib/solr.js
+++ b/lib/solr.js
@@ -83,7 +83,7 @@ function Client(options){
       agent : options.agent,
       secure : options.secure || false,
       bigint : options.bigint || false,
-      get_max: options.get_max || 2048
+      get_max_request_entity_size: options.get_max_request_entity_size || 2048
    };
 
    // Default paths of all request handlers
@@ -577,7 +577,7 @@ Client.prototype.get = function(handler,query,callback){
          .join('/'),
        approxUrlLength = 10 + this.options.host.length + (this.options.port+"").length + fullPath.length; // Buffer (10) accounts for protocol and special characters like ://, port colon, and initial slash etc
 
-   if (approxUrlLength <= this.options.get_max) {
+   if (approxUrlLength <= this.options.get_max_request_entity_size) {
       var params = {
          host: this.options.host,
          port: this.options.port,

--- a/lib/solr.js
+++ b/lib/solr.js
@@ -600,8 +600,6 @@ Client.prototype.post = function(handler,query,callback){
       parameters += query;
    }
 
-   console.log('QUERY = ', parameters);
-
    var fullPath = [this.options.path,this.options.core, handler + '?wt=json']
        .filter(function(element){
           return element;

--- a/lib/solr.js
+++ b/lib/solr.js
@@ -82,7 +82,8 @@ function Client(options){
       path : options.path || '/solr',
       agent : options.agent,
       secure : options.secure || false,
-      bigint : options.bigint || false
+      bigint : options.bigint || false,
+      get_max: options.get_max || 2048
    };
 
    // Default paths of all request handlers
@@ -507,7 +508,7 @@ Client.prototype.update = function(data,options,callback){
  */
 
 Client.prototype.search = function(query,callback){
-   return this.post(this.SELECT_HANDLER, query, callback);
+   return this.get(this.SELECT_HANDLER, query, callback);
 }
 
 /**
@@ -570,21 +571,28 @@ Client.prototype.get = function(handler,query,callback){
    }
 
    var fullPath = [this.options.path,this.options.core,handler + '?' + parameters + '&wt=json']
-                              .filter(function(element){
-                                 return element;
-                              })
-                              .join('/');
+         .filter(function(element){
+            return element;
+         })
+         .join('/'),
+       approxUrlLength = 10 + this.options.host.length + (this.options.port+"").length + fullPath.length; // Buffer (10) accounts for protocol and special characters like ://, port colon, and initial slash etc
 
-   var params = {
-      host : this.options.host,
-      port : this.options.port,
-      fullPath : fullPath,
-      secure : this.options.secure,
-      bigint : this.options.bigint,
-      authorization : this.options.authorization,
-      agent : this.options.agent
-   };
-   return getJSON(params,callback);
+   if (approxUrlLength <= this.options.get_max) {
+      var params = {
+         host: this.options.host,
+         port: this.options.port,
+         fullPath: fullPath,
+         secure: this.options.secure,
+         bigint: this.options.bigint,
+         authorization: this.options.authorization,
+         agent: this.options.agent
+      };
+      return getJSON(params, callback);
+   } else {
+
+      // Funnel this through a POST because it's too large
+      return this.post(handler, query, callback);
+   }
 }
 
 /**

--- a/lib/solr.js
+++ b/lib/solr.js
@@ -589,8 +589,7 @@ Client.prototype.get = function(handler,query,callback){
 
 Client.prototype.post = function(handler,query,callback){
 
-   var json = pickJSON(this.options.bigint).stringify(query);
-   var fullPath = [this.options.path,this.options.core, handler + '?' +'&wt=json']
+   var fullPath = [this.options.path,this.options.core, handler + '?wt=json']
        .filter(function(element){
           return element;
        })
@@ -600,13 +599,13 @@ Client.prototype.post = function(handler,query,callback){
       host : this.options.host,
       port : this.options.port,
       fullPath : fullPath,
-      json : json,
+      params : query.parameters.join('&'),
       secure : this.options.secure,
       bigint : this.options.bigint,
       authorization : this.options.authorization,
       agent : this.options.agent
    };
-   return postJSON(params,callback);
+   return postForm(params,callback);
 }
 
 /**
@@ -716,6 +715,41 @@ function postJSON(params,callback){
    });
 
    request.write(params.json);
+   request.end();
+
+   return request;
+};
+
+function postForm(params,callback){
+   var headers = {
+      'content-type' : 'application/x-www-form-urlencoded; charset=utf-8',
+      'content-length':  Buffer.byteLength(params.params),
+      'accept' : 'application/json; charset=utf-8'
+   };
+   if(params.authorization){
+      headers['authorization'] = params.authorization;
+   }
+   var options = {
+      host : params.host,
+      port : params.port,
+      method : 'POST',
+      headers : headers,
+      path : params.fullPath
+   };
+
+   if(params.agent !== undefined){
+      options.agent = params.agent;
+   }
+
+   var request = pickProtocol(params.secure).request(options);
+
+   request.on('response', handleJSONResponse(request, params.bigint, callback));
+
+   request.on('error',function onError(err){
+      if (callback) callback(err,null);
+   });
+
+   request.write(params.params);
    request.end();
 
    return request;

--- a/lib/solr.js
+++ b/lib/solr.js
@@ -587,6 +587,18 @@ Client.prototype.get = function(handler,query,callback){
    return getJSON(params,callback);
 }
 
+/**
+ * Send an arbitrary HTTP POST request to Solr on the specified `handler` (as Solr like to call it i.e path)
+ *
+ * @param {String} handler
+ * @param {Query|Object|String} [query]
+ * @param {Function} callback(err,obj) - a function executed when the Solr server responds or an error occurs
+ * @param {Error} callback().err
+ * @param {Object} callback().obj - JSON response sent by the Solr server deserialized
+ *
+ * @return {http.ClientRequest}
+ * @api public
+ */
 Client.prototype.post = function(handler,query,callback){
 
    var parameters = '';
@@ -730,6 +742,27 @@ function postJSON(params,callback){
 
    return request;
 };
+
+/**
+ * HTTP POST request. Send update commands to the Solr server using form encoding (e.g. search)
+ *
+ * @param {Object} params
+ * @param {String} params.host - IP address or host address of the Solr server
+ * @param {Number|String} params.port - port of the Solr server
+ * @param {String} params.core - name of the Solr core requested
+ * @param {String} params.authorization - value of the authorization header
+ * @param {String} params.fullPath - full path of the request
+ * @param {String} params.params - form params
+ * @param {Boolean} params.secure -
+ * @param {Boolean} params.bigint -
+ * @param {http.Agent} [params.agent] -
+ * @param {Function} callback(err,obj) - a function executed when the Solr server responds or an error occurs
+ * @param {Error} callback().err
+ * @param {Object} callback().obj - JSON response sent by the Solr server deserialized
+ *
+ * @return {http.ClientRequest}
+ * @api private
+ */
 
 function postForm(params,callback){
    var headers = {

--- a/lib/solr.js
+++ b/lib/solr.js
@@ -570,10 +570,10 @@ Client.prototype.get = function(handler,query,callback){
    }
 
    var fullPath = [this.options.path,this.options.core,handler + '?' + parameters + '&wt=json']
-       .filter(function(element){
-          return element;
-       })
-       .join('/');
+                              .filter(function(element){
+                                 return element;
+                              })
+                              .join('/');
 
    var params = {
       host : this.options.host,

--- a/lib/solr.js
+++ b/lib/solr.js
@@ -507,7 +507,7 @@ Client.prototype.update = function(data,options,callback){
  */
 
 Client.prototype.search = function(query,callback){
-   return this.get(this.SELECT_HANDLER, query, callback);
+   return this.post(this.SELECT_HANDLER, query, callback);
 }
 
 /**
@@ -570,10 +570,10 @@ Client.prototype.get = function(handler,query,callback){
    }
 
    var fullPath = [this.options.path,this.options.core,handler + '?' + parameters + '&wt=json']
-                              .filter(function(element){
-                                 return element;
-                              })
-                              .join('/');
+       .filter(function(element){
+          return element;
+       })
+       .join('/');
 
    var params = {
       host : this.options.host,
@@ -585,6 +585,28 @@ Client.prototype.get = function(handler,query,callback){
       agent : this.options.agent
    };
    return getJSON(params,callback);
+}
+
+Client.prototype.post = function(handler,query,callback){
+
+   var json = pickJSON(this.options.bigint).stringify(query);
+   var fullPath = [this.options.path,this.options.core, handler + '?' +'&wt=json']
+       .filter(function(element){
+          return element;
+       })
+       .join('/');
+
+   var params = {
+      host : this.options.host,
+      port : this.options.port,
+      fullPath : fullPath,
+      json : json,
+      secure : this.options.secure,
+      bigint : this.options.bigint,
+      authorization : this.options.authorization,
+      agent : this.options.agent
+   };
+   return postJSON(params,callback);
 }
 
 /**

--- a/lib/solr.js
+++ b/lib/solr.js
@@ -83,7 +83,7 @@ function Client(options){
       agent : options.agent,
       secure : options.secure || false,
       bigint : options.bigint || false,
-      get_max_request_entity_size: options.get_max_request_entity_size || 2048
+      get_max_request_entity_size: options.get_max_request_entity_size || false
    };
 
    // Default paths of all request handlers
@@ -575,9 +575,9 @@ Client.prototype.get = function(handler,query,callback){
             return element;
          })
          .join('/'),
-       approxUrlLength = 10 + this.options.host.length + (this.options.port+"").length + fullPath.length; // Buffer (10) accounts for protocol and special characters like ://, port colon, and initial slash etc
+       approxUrlLength = 10 + Buffer.byteLength(this.options.host) + (this.options.port+"").length + Buffer.byteLength(fullPath); // Buffer (10) accounts for protocol and special characters like ://, port colon, and initial slash etc
 
-   if (approxUrlLength <= this.options.get_max_request_entity_size) {
+   if (this.options.get_max_request_entity_size === false || approxUrlLength <= this.options.get_max_request_entity_size) {
       var params = {
          host: this.options.host,
          port: this.options.port,

--- a/lib/solr.js
+++ b/lib/solr.js
@@ -589,6 +589,19 @@ Client.prototype.get = function(handler,query,callback){
 
 Client.prototype.post = function(handler,query,callback){
 
+   var parameters = '';
+   if(typeof query === 'function'){
+      callback = query;
+   }else if(query instanceof Query){
+      parameters += query.build();
+   }else if(typeof query === 'object'){
+      parameters += querystring.stringify(query);
+   }else if(typeof query === 'string'){
+      parameters += query;
+   }
+
+   console.log('QUERY = ', parameters);
+
    var fullPath = [this.options.path,this.options.core, handler + '?wt=json']
        .filter(function(element){
           return element;
@@ -599,7 +612,7 @@ Client.prototype.post = function(handler,query,callback){
       host : this.options.host,
       port : this.options.port,
       fullPath : fullPath,
-      params : query.parameters.join('&'),
+      params : parameters,
       secure : this.options.secure,
       bigint : this.options.bigint,
       authorization : this.options.authorization,

--- a/test/config.json
+++ b/test/config.json
@@ -3,6 +3,6 @@
     "host": "127.0.0.1",
     "port": 8983,
     "path": "/solr",
-    "core": "solr_client_test"
+    "core": null
   }
 }

--- a/test/config.json
+++ b/test/config.json
@@ -3,6 +3,6 @@
     "host": "127.0.0.1",
     "port": 8983,
     "path": "/solr",
-    "core": null
+    "core": "solr_client_test"
   }
 }


### PR DESCRIPTION
Greetings,

I've made a modification to the search method to use HTTP POST instead of GET. The reasoning is that for large queries, GET will fail with 413 - Request Entity Too Large.

Since there's no real performance difference, I just simply swapped out the functionality to use POST instead of making it configurable. 

I tried running unit tests, however nine fail against solr 5.1 even without the changes, so it appears like all is well.

Thanks,
-Kevin