### PR TITLE
Added a method in the query class to set the default field to search.

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -110,6 +110,22 @@ Query.prototype.qop = function(op){
 };
 
 /**
+ * Set the default query field.
+ *
+ * @param {String} df - the default field where solr should search.
+ *
+ * @return  {Query}
+ * @api public
+ */
+Query.prototype.df = function (df) {
+    var self = this;
+    var parameter = 'df=';
+    parameter += df;
+    this.parameters.push(parameter);
+    return self;
+};
+
+/**
  * Set the offset where the set of returned documents should begin.
  *
  * @param {Number} start - the offset where the set of returned documents should begin.

--- a/test/core-query-test.js
+++ b/test/core-query-test.js
@@ -153,6 +153,21 @@ describe('Client#createQuery',function(){
 			});
 		});
 
+		it('df - Default field query',function(done){
+
+			var query = client.createQuery()
+				.q("ali").df("author").debugQuery();
+
+			client.search(query, function(err, data){
+				sassert.ok(err, data);
+				assert.deepEqual(data.responseHeader.params,
+					{ debugQuery: "true"
+						, q: "ali", "df": "author"
+						, wt: 'json'});
+				done();
+			});
+		});
+
 		it('query with range-filter',function(done){
 
 			var query = client.createQuery()


### PR DESCRIPTION
The only way to set a default field in the query is to add it in the query string, so the q() method would be wasted, so adding this method allow to specify the default field to search.