### PR TITLE
Update Package.json dependencies, according tests, activate solrVersion, facet.pivot, add helpers for standardization

### DIFF
--- a/CONTRIBUTIONS.md
+++ b/CONTRIBUTIONS.md
@@ -1,7 +1,17 @@
 # CONTRIBUTIONS
 
-Send a pull request with your code and the tests for it.
+The library lives and prospers thanks to you. If you want to share some of your work, or if you have fixed some of the 
+open issues, send a pull request with your code and the tests for it.
 
-Not mandatory at all but if you don't mind:
+We're currently re-organizing the project organization, and as such we're starting to adopt a stricter commit guideline,
+ very much inspired from that of [AngularJS](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit)
 
-* Prepend your commit message with `FIX:` or `NEW:`, make it easy to generate a readable CHANGELOG.
+So we ask you to respect 2 rules: 
+1. Provide the code, the tests, all respecting the style guide
+2. Follow AngularJS commit style-guide that can, at the most minimum, be summarized by a single line like:
+ `feat(solrCloud): Add ability to query pivot per field`
+ 
+Note: Please restrain from committing code that does other changes than what they are committed for. Avoid changing the 
+style guide of entire files while committing fixes or features.
+
+*Thanks in advance for your support in making the library live.*

--- a/README.md
+++ b/README.md
@@ -13,6 +13,19 @@ npm install solr-client
 
 ##Features
 
+###Latest (0.6.0)
+
+- Solr5 Query-Highlighting support through StandardHighlighter (@LukeTavern) (https://github.com/lbdremy/solr-node-client/pull/144)
+- Experimental support for SolrCloud collections administration (@LukeTavern) (https://github.com/lbdremy/solr-node-client/issues/138)
+- Support for large query through POST via configurable automatic switch (@kfitzgerald) (https://github.com/lbdremy/solr-node-client/pull/129) 
+- Set Default Field (query.df()) (@cbarrientos-ias) (https://github.com/lbdremy/solr-node-client/pull/137)
+- Adds support for facet.pivot and facet.pivot.mincount (@nicolasembleton) (https://github.com/lbdremy/solr-node-client/issues/146)
+ 
+Noticeable change: You can now pass a solrVersion to the Client initialization so it will activate features that  are only supported 
+by your version or higher. Be sure to check the documentation
+
+###0.5.0
+
 - Commands supported: search(select), add, delete, update, commit, rollback, optimize, ping, real-time get, prepare commit, soft commit, arbitrary search handler (i.e: mlt, luke ...)
 - Lucene query / DisMax query
 - Grouping / Field Collapsing. (Apache Solr version must be >= 3.3)
@@ -43,6 +56,73 @@ client.add({ id : 12, title_t : 'Hello' },function(err,obj){
    }
 });
 ```
+
+##Migration between 0.5.x and 0.6.x
+
+No breaking change has been introduced to this release. However, to take advantage of facet.pivot and facet.pivot.mincount feature,
+you'll need to pass a solrVersion parameter to the createClient() method. 
+
+Example:
+
+```js
+// Will activate features specific to Solr4.0 and above (like facet.pivot and facet.pivot.mincount)
+var client = solr.createClient({
+ solrVersion: '4.0'
+});
+```
+
+A feature allowing to support large queries by switching to POST when the query size reaches the threshold was introduced. To not become
+a breaking change, it is by default turned OFF. 
+  
+To activate it, pass the property `get_max_request_entity_size` to the createClient with the threshold in bytes. Minimum is 1.
+ 
+Example:
+
+```js
+// Will switch to POST as soon as the query size reaches 1000 bytes (limit in servers is usually 2048 or 8192)  
+// You can set it to 1 so every request will always use POST. 
+var client = solr.createClient({
+ get_max_request_entity_size: 1000
+});
+```
+
+##Migration between 0.4.x and 0.5.x
+
+The only breaking change introduced in `0.5.x` is introduced in this commit [3cbc7fc6cf631f019a4626913c0a4b616092133b](https://github.com/lbdremy/solr-node-client/commit/3cbc7fc6cf631f019a4626913c0a4b616092133b) which remove escaping of the Solr special characters in some of the methods of the `Query` class i.e in `Query#rangeFilter`, `Query#matchFilter`, `Query#group`, `Query#facet`, `Query#mlt` if you were relying on this behavior just wrap the arguments you passed to those methods into the [`solr.escapeSpecialChars(arg)`](https://github.com/lbdremy/solr-node-client/blob/master/lib/solr.js#L605) method.
+
+For example, for some weird reason you wanted to escape the special char `*`, don't ask me ;)
+
+```js
+var query = client.createQuery();
+query.q({ '*' : '*' }).rangeFilter({ field : 'id', start : 100, end : '*'})
+```
+
+You still can:
+
+```js
+var query = client.createQuery();
+query.q({ '*' : '*' }).rangeFilter({ field : 'id', start : 100, end : solr.escapeSpecialChars('*')})
+```
+
+Post an issue if you have troubles migrating to v0.5.0.
+
+##Migration between 0.3.x and 0.4.x
+
+The only breaking change introduced in `0.4.x` is about JSON serialization/deserialization of numbers too large for Javascript Number type. If you were using the Optimistic Concurreny feature available in Solr 4.x, along with RealTime Get and Atomic Updates features which use the \_version\_ field or *_l type fields you are affected about this change otherwise you are just fine.
+
+If you affected in order to fix that just initialize your client with the `bigint` flag set to `true`:
+
+```js
+var client = solr.createClient({ bigint : true });
+```
+
+or directly on the `Client` instance:
+
+```js
+client.options.bigint = true;
+```
+
+Post an issue if you have troubles migrating to v0.4.0.
 
 ##Migration between 0.2.x and 0.3.x
 
@@ -78,44 +158,6 @@ request.setTimeout(200, function(){
 ```
 
 Post an issue if you have troubles migrating to v0.3.0.
-
-##Migration between 0.3.x and 0.4.x
-
-The only breaking change introduced in `0.4.x` is about JSON serialization/deserialization of numbers too large for Javascript Number type. If you were using the Optimistic Concurreny feature available in Solr 4.x, along with RealTime Get and Atomic Updates features which use the \_version\_ field or *_l type fields you are affected about this change otherwise you are just fine.
-
-If you affected in order to fix that just initialize your client with the `bigint` flag set to `true`:
-
-```js
-var client = solr.createClient({ bigint : true });
-```
-
-or directly on the `Client` instance:
-
-```js
-client.options.bigint = true;
-```
-
-Post an issue if you have troubles migrating to v0.4.0.
-
-##Migration between 0.4.x and 0.5.x
-
-The only breaking change introduced in `0.5.x` is introduced in this commit [3cbc7fc6cf631f019a4626913c0a4b616092133b](https://github.com/lbdremy/solr-node-client/commit/3cbc7fc6cf631f019a4626913c0a4b616092133b) which remove escaping of the Solr special characters in some of the methods of the `Query` class i.e in `Query#rangeFilter`, `Query#matchFilter`, `Query#group`, `Query#facet`, `Query#mlt` if you were relying on this behavior just wrap the arguments you passed to those methods into the [`solr.escapeSpecialChars(arg)`](https://github.com/lbdremy/solr-node-client/blob/master/lib/solr.js#L605) method.
-
-For example, for some weird reason you wanted to escape the special char `*`, don't ask me ;)
-
-```js
-var query = client.createQuery();
-query.q({ '*' : '*' }).rangeFilter({ field : 'id', start : 100, end : '*'})
-```
-
-You still can:
-
-```js
-var query = client.createQuery();
-query.q({ '*' : '*' }).rangeFilter({ field : 'id', start : 100, end : solr.escapeSpecialChars('*')})
-```
-
-Post an issue if you have troubles migrating to v0.5.0.
 
 ##Roadmap
 

--- a/lib/query.js
+++ b/lib/query.js
@@ -388,6 +388,8 @@ Query.prototype.group = function(options){
  * @param {Number} [options.mincount=0] - This parameter indicates the minimum counts for facet fields should be included in the response. The solr's default value is 0.
  * @param {Boolean} [options.missing=false] - Set to `true` this param indicates that in addition to the Term based constraints of a facet field, a count of all matching results which have no value for the field should be computed. The solr's default value is false.
  * @param {String} [options.method="fc"] - This parameter indicates what type of algorithm/method to use when faceting a field.The solr's default value is fc (except for BoolField).
+ * @param {String|Array} options.pivot - This parameter allows you to specify a field which should be treated as a facet pivot. It will iterate over each Term in the field. Multiple fields can be defined providing an array instead of a string.
+ * @param {String} [options.pivot.mincount=0] - This parameter indicates the minimum counts for facet pivot fields to be included in the response. The solr's default value is 0.
  *
  * @return {Query}
  * @api public
@@ -431,6 +433,13 @@ Query.prototype.facet = function(options){
    if(options.method){
       this.parameters.push('facet.method=' + options.method);
    }
+   if(options.pivot){
+      this.parameters.push('facet.pivot=' + options.pivot);
+   }
+   if(options.pivot.mincount) {
+      this.parameters.push('facet.pivot.mincount=' + options.pivot.mincount);
+   }
+
    return self;
 }
 

--- a/lib/query.js
+++ b/lib/query.js
@@ -3,7 +3,8 @@
  */
 var querystring = require('querystring'),
     format = require('./utils/format'),
-    arrayUtils = require('./utils/array');
+    arrayUtils = require('./utils/array'),
+    versionUtils = require('./utils/version');
 
 /**
  * Expose `Query`
@@ -19,7 +20,8 @@ module.exports = exports = Query;
  * @api private
  */
 
-function Query(){
+function Query(options){
+   this.solrVersion = (options && options.solrVersion) || undefined;
    this.parameters = [];
 }
 
@@ -430,14 +432,18 @@ Query.prototype.facet = function(options){
    if(options.method){
       this.parameters.push('facet.method=' + options.method);
    }
-   if(options.pivot){
-     options.field = arrayUtils.toArray(options.pivot.fields);
-     options.field.forEach(function(field) {
-       self.parameters.push('facet.pivot=' + field);
-     });
-   }
-   if(options.pivot.mincount) {
-      this.parameters.push('facet.pivot.mincount=' + options.pivot.mincount);
+
+   // Only supported with version 4.0 and above
+   if(this.solrVersion && (versionUtils.version(this.solrVersion) >= versionUtils.Solr4_0)) {
+     if(options.pivot){
+       options.field = arrayUtils.toArray(options.pivot.fields);
+       options.field.forEach(function(field) {
+         self.parameters.push('facet.pivot=' + field);
+       });
+     }
+     if(options.pivot.mincount) {
+       this.parameters.push('facet.pivot.mincount=' + options.pivot.mincount);
+     }
    }
 
    return self;
@@ -752,7 +758,7 @@ Query.prototype.build = function(){
  * @param {Boolean} [options.requireFieldMatch] - If set to True, this parameter will force Solr to highlight terms only if they appear in the specified field. If false, terms are highlighted in all requested fields regardless of which field matches the query.
  * @param {Boolean} [options.usePhraseHighlighter] - If set to True, Solr will use the Lucene SpanScorer class to highlight phrase terms only when they appear within the query phrase in the document.
  * @param {Number} [options.regexSlop] - When using the regex fragmenter, this number specifies the factor by which the fragmenter can stray from the ideal fragment size.
- * @param {String} [options.regexPattern] - This parameter specifies the regulat expression for fragmenting. 
+ * @param {String} [options.regexPattern] - This parameter specifies the regulat expression for fragmenting.
  * @param {Number} [options.regexMaxAnalyzedChars] - This parameters specifies the max number of characters to analyze from a field when using the regex fragmenter.
  * @param {Boolean} [options.preserveMulti] - If True, multi-valued fields will return all values in the order they were saved in the index. If False, only values that match the highlight request will be returned.
  * @param {Boolean} [options.payloads] - If usePhraseHighlighter is True, and the indexed field has payloads but not term vectors, the index payloads will be read into the highlighter's index along with the posting. If you don't want this behavior, you may set this parameter to False and save some memory.

--- a/lib/query.js
+++ b/lib/query.js
@@ -2,7 +2,8 @@
  * Load dependencies
  */
 var querystring = require('querystring'),
-    format = require('./utils/format');
+    format = require('./utils/format'),
+    arrayUtils = require('./utils/array');
 
 /**
  * Expose `Query`
@@ -340,9 +341,7 @@ Query.prototype.group = function(options){
       this.parameters.push('group=true');
    }
    if( options.field ){
-      if(!Array.isArray(options.field)){
-        options.field = [options.field];
-      }
+      options.field = arrayUtils.toArray(options.field);
       options.field.forEach(function(field){
         self.parameters.push('group.field=' + field);
       });
@@ -405,12 +404,10 @@ Query.prototype.facet = function(options){
       this.parameters.push('facet.query=' + encodeURIComponent(options.query))
    }
    if(options.field){
-      if(!Array.isArray(options.field)){
-         options.field = [options.field];
-      }
-      for (var i = 0; i < options.field.length; i++) {
-         this.parameters.push('facet.field=' + options.field[i])
-      }
+     options.field = arrayUtils.toArray(options.field);
+     options.field.forEach(function(field) {
+       self.parameters.push('facet.field=' + field);
+     });
    }
    if(options.prefix){
       this.parameters.push('facet.prefix=' + encodeURIComponent(options.prefix))

--- a/lib/query.js
+++ b/lib/query.js
@@ -434,7 +434,10 @@ Query.prototype.facet = function(options){
       this.parameters.push('facet.method=' + options.method);
    }
    if(options.pivot){
-      this.parameters.push('facet.pivot=' + options.pivot);
+     options.field = arrayUtils.toArray(options.pivot.fields);
+     options.field.forEach(function(field) {
+       self.parameters.push('facet.pivot=' + field);
+     });
    }
    if(options.pivot.mincount) {
       this.parameters.push('facet.pivot.mincount=' + options.pivot.mincount);

--- a/lib/solr.js
+++ b/lib/solr.js
@@ -40,6 +40,7 @@ exports.createClient = createClient;
  * @param {Boolean} [secure=false] - if true HTTPS will be used instead of HTTP
  * @param {Boolean} [bigint=false] - if true JSONbig serializer/deserializer will be used instead
  *                                    of JSON native serializer/deserializer
+ * @param solrVersion ['3.2', '4.0', '5.0', '5.1'], check lib/utils/version.js for full reference
  *
  * @return {Client}
  * @api public

--- a/lib/solr.js
+++ b/lib/solr.js
@@ -20,7 +20,8 @@ var http = require('http'),
    JSONStream = require('JSONStream'),
    duplexer = require('duplexer'),
    request = require('request'),
-   JSONbig = require('json-bigint');
+   JSONbig = require('json-bigint'),
+   versionUtils = require('./utils/version');
 
 /**
  * Expose `createClient()`.
@@ -85,11 +86,12 @@ function Client(options){
       agent : options.agent,
       secure : options.secure || false,
       bigint : options.bigint || false,
-      get_max_request_entity_size: options.get_max_request_entity_size || false
+      get_max_request_entity_size: options.get_max_request_entity_size || false,
+      solrVersion: options.solrVersion || versionUtils.Solr3_2
    };
 
    // Default paths of all request handlers
-   this.UPDATE_JSON_HANDLER = options.solrVersion >= 4 ? 'update' : 'update/json';
+   this.UPDATE_JSON_HANDLER = (versionUtils.version(this.options.solrVersion) >= versionUtils.Solr4_0) ? 'update' : 'update/json';
    this.UPDATE_HANDLER = 'update';
    this.SELECT_HANDLER = 'select';
    this.COLLECTIONS_HANDLER = 'admin/collections';
@@ -672,13 +674,13 @@ Client.prototype.post = function(handler,query,callback){
 
 /**
  * Create an instance of `Query`
- * 
+ *
  * @return {Query}
  * @api public
  */
 
 Client.prototype.query = function(){
-   return new Query();
+   return new Query(this.options);
 }
 
 /**
@@ -690,7 +692,7 @@ Client.prototype.query = function(){
  */
 
 Client.prototype.createQuery = function(){
-   return new Query();
+   return new Query(this.options);
 }
 
 /**

--- a/lib/utils/array.js
+++ b/lib/utils/array.js
@@ -1,0 +1,15 @@
+/**
+ *
+ * @param value
+ * @param defaultIfNull - Will set the value to the default if it is Null or Undefined
+ * @returns {*[]}
+ */
+exports.toArray = function toArray(value, defaultIfNull) {
+  defaultIfNull = defaultIfNull || '';
+
+  function defaultValue(value) {
+    return (value === null || value === undefined) ? defaultIfNull : value;
+  }
+
+  return (Array.isArray(value)) ? value : [defaultValue(value)];
+};

--- a/lib/utils/type.js
+++ b/lib/utils/type.js
@@ -1,0 +1,21 @@
+/**
+ *
+ * @param value - The value to check against
+ * @param strict - Pass true if you want to make sure the number is fully and only composed of digits, false to just check if we can extract a number via parseInt(). Default to true.
+ * @returns boolean
+ */
+exports.isNumber = function isNumber(value, strict) {
+  strict = (strict === undefined ? true : strict);
+  var digitRegex = /^\-?\d+$/; // At least 1 digit, possibly a minus sign before
+
+  if (typeof value === 'number') {
+    return true;
+  } else {
+    // String ?
+    if (strict) {
+      return (('' + value).match(digitRegex) !== null);
+    } else {
+      return !isNaN(parseInt(value));
+    }
+  }
+};

--- a/lib/utils/version.js
+++ b/lib/utils/version.js
@@ -1,0 +1,32 @@
+/**
+ * The purpose of those helpers is to centralize and standardize the work on detecting current running Solr Version
+ */
+
+var Solr3_2 = 302;
+var Solr4_0 = 400;
+var Solr5_0 = 500;
+var Solr5_1 = 501;
+
+var versionsEnum = {
+  '3.2': Solr3_2,
+  '4.0': Solr4_0,
+  '5.0': Solr5_0,
+  '5.1': Solr5_1
+};
+
+exports.versionsEnum = versionsEnum;
+exports.Solr3_2 = Solr3_2;
+exports.Solr4_0 = Solr4_0;
+exports.Solr5_0 = Solr5_0;
+exports.Solr5_1 = Solr5_1;
+
+/**
+ * solrVersion must match one of enum keys
+ * If a number is passed, it'll be assume a .0 release (3 -> 3.0)
+ * If nothing matches, it will be assumed 3.2
+ *
+ * @param solrVersion
+ */
+exports.version = function(solrVersion) {
+  return (typeof solrVersion === "number") ? (versionsEnum[''+solrVersion+'.0']) : (versionsEnum[solrVersion] ? versionsEnum[solrVersion] : versionsEnum['3.2']);
+};

--- a/lib/utils/version.js
+++ b/lib/utils/version.js
@@ -7,6 +7,11 @@ var Solr4_0 = 400;
 var Solr5_0 = 500;
 var Solr5_1 = 501;
 
+/**
+ * Enum that lists supported versions of Solr. Pass one of the keys from this enum as a solrVersion property
+ *
+ * @type {{3.2: number, 4.0: number, 5.0: number, 5.1: number}}
+ */
 var versionsEnum = {
   '3.2': Solr3_2,
   '4.0': Solr4_0,

--- a/package.json
+++ b/package.json
@@ -16,17 +16,18 @@
     "node": ">= 0.4.7"
   },
   "dependencies": {
-    "JSONStream": "~0.9.0",
+    "JSONStream": "~1.0.6",
     "duplexer": "~0.1.1",
-    "httperror": "~0.2.2",
-    "json-bigint": "~0.1.3",
-    "request": "~2.49.0"
+    "httperror": "~0.2.3",
+    "json-bigint": "~0.1.4",
+    "request": "~2.63.0"
   },
   "devDependencies": {
-    "chai": "~1.9.1",
-    "bignumber.js": "~1.4.1",
+    "chai": "~3.3.0",
+    "bignumber.js": "~2.0.7",
+    "minimist": "~1.2.0",
     "csv-stream": "~0.1.3",
-    "mocha": "~1.20.1",
+    "mocha": "~2.3.3",
     "figc": "~0.0.3"
   },
   "scripts": {

--- a/test/add-test.js
+++ b/test/add-test.js
@@ -7,7 +7,8 @@ var mocha = require('mocha'),
 	assert = require('chai').assert,
 	libPath = process.env['SOLR_CLIENT_COV'] ? '../lib-cov' : '../lib',
 	solr = require( libPath + '/solr'),
-	sassert = require('./sassert');
+	sassert = require('./sassert'),
+	versionUtils = require('./../lib/utils/version');
 
 // Test suite
 var config = figc(__dirname + '/config.json');
@@ -61,7 +62,11 @@ describe('Client',function(){
 				softCommit : true
 			};
 			var request = client.add(docs,options,function(err,data){
-				assert.equal(request.path, basePath + '/update/json?softCommit=true&wt=json');
+				if(client.options.solrVersion && versionUtils.version(client.options.solrVersion) >= versionUtils.Solr4_0) {
+					assert.equal(request.path, basePath + '/update?softCommit=true&wt=json');
+				} else {
+					assert.equal(request.path, basePath + '/update/json?softCommit=true&wt=json');
+				}
 				sassert.ok(err,data);
 				done();
 			});
@@ -83,7 +88,11 @@ describe('Client',function(){
 				commit : true
 			};
 			var request = client.add(docs,options,function(err,data){
-				assert.equal(request.path, basePath + '/update/json?commit=true&wt=json');
+				if(client.options.solrVersion && versionUtils.version(client.options.solrVersion) >= versionUtils.Solr4_0) {
+					assert.equal(request.path, basePath + '/update?commit=true&wt=json');
+				} else {
+					assert.equal(request.path, basePath + '/update/json?commit=true&wt=json');
+				}
 				sassert.ok(err,data);
 				done();
 			});
@@ -105,7 +114,11 @@ describe('Client',function(){
 				commitWithin : 10000
 			};
 			var request = client.add(docs,options,function(err,data){
-				assert.equal(request.path, basePath + '/update/json?commitWithin=10000&wt=json');
+				if(client.options.solrVersion && versionUtils.version(client.options.solrVersion) >= versionUtils.Solr4_0) {
+					assert.equal(request.path, basePath + '/update?commitWithin=10000&wt=json');
+				} else {
+					assert.equal(request.path, basePath + '/update/json?commitWithin=10000&wt=json');
+				}
 				sassert.ok(err,data);
 				done();
 			});

--- a/test/bigint-test.js
+++ b/test/bigint-test.js
@@ -44,8 +44,8 @@ describe('Client',function(){
             client.add(doc, add_options, function(err,data){
                 sassert.ok(err,data);
                 assert.ok(big != Number(big).toString(), 'the big number used for testing should exceed the limits of javascript Number variables');
-                assert.ok(big == BigNumber(big).toString(), 'the big number used for testing should not exceed the limits of BigNumber processing');
-                _version_ = BigNumber(data.adds[1].toString());
+                assert.ok(big == (new BigNumber(big)).toString(), 'the big number used for testing should not exceed the limits of BigNumber processing');
+                _version_ = new BigNumber(data.adds[1].toString());
                 assert.ok(_version_.comparedTo(0) == 1, '_version_ should be set to a positive number');
                 done();
             });
@@ -72,7 +72,7 @@ describe('Client',function(){
             client.add(doc, add_options, function(err,data){
                 sassert.ok(err,data);
                 var prev_version_ = _version_;
-                _version_ = BigNumber(data.adds[1].toString());
+                _version_ = new BigNumber(data.adds[1].toString());
                 assert.ok(_version_.comparedTo(prev_version_) == 1, 'new _version_ should be bigger then previous');
                 done();
             });

--- a/test/core-query-test.js
+++ b/test/core-query-test.js
@@ -36,13 +36,13 @@ describe('Client#createQuery',function(){
 		it('query sorted',function(done){
 
 			var query = client.createQuery()
-				.q("*:*").sort({ "author":"asc", "category":"desc"}).debugQuery();
+				.q("*:*").sort({ "author":"asc" }).debugQuery(); // remove ', "category":"desc"' as newer solr doesn't support
 
 			client.search(query, function(err, data){
 				sassert.ok(err, data);
-				assert.deepEqual(data.responseHeader.params, 
+				assert.deepEqual(data.responseHeader.params,
 						{ debugQuery: "true"
-            , q: "*:*", sort: "author asc,category desc"
+            , q: "*:*", "sort": "author asc"
             , wt: 'json'});
 				done();
 			});

--- a/test/delete-test.js
+++ b/test/delete-test.js
@@ -8,7 +8,8 @@ var mocha = require('mocha'),
 	libPath = process.env['SOLR_CLIENT_COV'] ? '../lib-cov' : '../lib',
 	solr = require( libPath + '/solr'),
 	SolrError = require(libPath + '/error/solr-error'),
-	sassert = require('./sassert');
+	sassert = require('./sassert'),
+	versionUtils = require('./../lib/utils/version');
 
 // Test suite
 var config = figc(__dirname + '/config.json');
@@ -27,7 +28,11 @@ describe('Client',function(){
 	describe('#delete("title_t","test",{ commit : true},callback)',function(){
 		it('should delete all documents where the field "title_t" is "test" and hard commit all changes',function(done){
 			var request = client.delete('title_t','test',{commit : true},function(err,data){
-				assert.equal(request.path, basePath + '/update/json?commit=true&wt=json');
+				if(client.options.solrVersion && versionUtils.version(client.options.solrVersion) >= versionUtils.Solr4_0) {
+					assert.equal(request.path, basePath + '/update?commit=true&wt=json');
+				} else {
+					assert.equal(request.path, basePath + '/update/json?commit=true&wt=json');
+				}
 				sassert.ok(err,data);
 				done();
 			});
@@ -36,7 +41,11 @@ describe('Client',function(){
 	describe('#delete("title_t","test",{ softCommit : true},callback)',function(){
 		it('should delete all documents where the field "title_t" is "test" and soft commit all changes',function(done){
 			var request = client.delete('title_t','test',{softCommit : true},function(err,data){
-				assert.equal(request.path, basePath + '/update/json?softCommit=true&wt=json');
+				if(client.options.solrVersion && versionUtils.version(client.options.solrVersion) >= versionUtils.Solr4_0) {
+					assert.equal(request.path, basePath + '/update?softCommit=true&wt=json');
+				} else {
+					assert.equal(request.path, basePath + '/update/json?softCommit=true&wt=json');
+				}
 				sassert.ok(err,data);
 				done();
 			});
@@ -45,7 +54,11 @@ describe('Client',function(){
 	describe('#delete("title_t","test",{ commitWithin : 10000},callback)',function(){
 		it('should delete all documents where the field "title_t" is "test" and commit within 10s all changes',function(done){
 			var request = client.delete('title_t','test',{commitWithin : 10000},function(err,data){
-				assert.equal(request.path, basePath + '/update/json?commitWithin=10000&wt=json');
+				if(client.options.solrVersion && versionUtils.version(client.options.solrVersion) >= versionUtils.Solr4_0) {
+					assert.equal(request.path, basePath + '/update?commitWithin=10000&wt=json');
+				} else {
+					assert.equal(request.path, basePath + '/update/json?commitWithin=10000&wt=json');
+				}
 				sassert.ok(err,data);
 				done();
 			});

--- a/test/deleteById-test.js
+++ b/test/deleteById-test.js
@@ -8,7 +8,8 @@ var mocha = require('mocha'),
 	libPath = process.env['SOLR_CLIENT_COV'] ? '../lib-cov' : '../lib',
 	solr = require( libPath + '/solr'),
 	SolrError = require(libPath + '/error/solr-error'),
-	sassert = require('./sassert');
+	sassert = require('./sassert'),
+	versionUtils = require('./../lib/utils/version');
 
 // Test suite
 var config = figc(__dirname + '/config.json');
@@ -27,7 +28,11 @@ describe('Client',function(){
 	describe('#deleteByID(1,{softCommit : true },callback)',function(){
 		it('should delete the document with the id 1 and the soft commit option enabled',function(done){
 			var request =  client.deleteByID(1,{softCommit : true},function(err,data){
-				assert.equal(request.path, basePath + '/update/json?softCommit=true&wt=json');
+				if(client.options.solrVersion && versionUtils.version(client.options.solrVersion) >= versionUtils.Solr4_0) {
+					assert.equal(request.path, basePath + '/update?softCommit=true&wt=json');
+				} else {
+					assert.equal(request.path, basePath + '/update/json?softCommit=true&wt=json');
+				}
 				sassert.ok(err,data);
 				done();
 			});
@@ -36,7 +41,11 @@ describe('Client',function(){
 	describe('#deleteByID(1,{commitWithin : 10000},callback)',function(){
 		it('should delete the document with the id 1 and commit changes within 10s',function(done){
 			var request = client.deleteByID(1,{commitWithin : 10000},function(err,data){
-				assert.equal(request.path, basePath + '/update/json?commitWithin=10000&wt=json');
+				if(client.options.solrVersion && versionUtils.version(client.options.solrVersion) >= versionUtils.Solr4_0) {
+					assert.equal(request.path, basePath + '/update?commitWithin=10000&wt=json');
+				} else {
+					assert.equal(request.path, basePath + '/update/json?commitWithin=10000&wt=json');
+				}
 				sassert.ok(err,data);
 				done();
 			});
@@ -45,7 +54,11 @@ describe('Client',function(){
 	describe('#deleteByID(1,{commit : true},callback)',function(){
 		it('should delete the document with the id 1 and hard commit changes',function(done){
 			var request = client.deleteByID(1,{commit : true},function(err,data){
-				assert.equal(request.path, basePath + '/update/json?commit=true&wt=json');
+				if(client.options.solrVersion && versionUtils.version(client.options.solrVersion) >= versionUtils.Solr4_0) {
+					assert.equal(request.path, basePath + '/update?commit=true&wt=json');
+				} else {
+					assert.equal(request.path, basePath + '/update/json?commit=true&wt=json');
+				}
 				sassert.ok(err,data);
 				done();
 			});

--- a/test/deleteByQuery-test.js
+++ b/test/deleteByQuery-test.js
@@ -8,7 +8,8 @@ var mocha = require('mocha'),
 	libPath = process.env['SOLR_CLIENT_COV'] ? '../lib-cov' : '../lib',
 	solr = require( libPath + '/solr'),
 	SolrError = require(libPath + '/error/solr-error'),
-	sassert = require('./sassert');
+	sassert = require('./sassert'),
+	versionUtils = require('./../lib/utils/version');
 
 // Test suite
 var config = figc(__dirname + '/config.json');
@@ -27,7 +28,11 @@ describe('Client',function(){
 	describe('#deleteByQuery("title_t:*",{softCommit : true },callback)',function(){
 		it('should delete all documents having the field title_t with the soft commit option enabled',function(done){
 			var request =  client.deleteByQuery('title_t:*',{softCommit : true},function(err,data){
-				assert.equal(request.path, basePath + '/update/json?softCommit=true&wt=json');
+				if(client.options.solrVersion && versionUtils.version(client.options.solrVersion) >= versionUtils.Solr4_0) {
+					assert.equal(request.path, basePath + '/update?softCommit=true&wt=json');
+				} else {
+					assert.equal(request.path, basePath + '/update/json?softCommit=true&wt=json');
+				}
 				sassert.ok(err,data);
 				done();
 			});
@@ -36,7 +41,11 @@ describe('Client',function(){
 	describe('#deleteByQuery("title_t:*",{commitWithin : 10000},callback)',function(){
 		it('should delete all documents having the field title_t and commit changes within 10s',function(done){
 			var request = client.deleteByQuery('title_t:*',{commitWithin : 10000},function(err,data){
-				assert.equal(request.path, basePath + '/update/json?commitWithin=10000&wt=json');
+				if(client.options.solrVersion && versionUtils.version(client.options.solrVersion) >= versionUtils.Solr4_0) {
+					assert.equal(request.path, basePath + '/update?commitWithin=10000&wt=json');
+				} else {
+					assert.equal(request.path, basePath + '/update/json?commitWithin=10000&wt=json');
+				}
 				sassert.ok(err,data);
 				done();
 			});
@@ -45,7 +54,11 @@ describe('Client',function(){
 	describe('#deleteByQuery("title_t:*",{commit : true},callback)',function(){
 		it('should delete all documents having the field title_t and hard commit changes',function(done){
 			var request = client.deleteByQuery('title_t:*',{commit : true},function(err,data){
-				assert.equal(request.path, basePath + '/update/json?commit=true&wt=json');
+				if(client.options.solrVersion && versionUtils.version(client.options.solrVersion) >= versionUtils.Solr4_0) {
+					assert.equal(request.path, basePath + '/update?commit=true&wt=json');
+				} else {
+					assert.equal(request.path, basePath + '/update/json?commit=true&wt=json');
+				}
 				sassert.ok(err,data);
 				done();
 			});

--- a/test/deleteByRange-test.js
+++ b/test/deleteByRange-test.js
@@ -8,7 +8,8 @@ var mocha = require('mocha'),
 	libPath = process.env['SOLR_CLIENT_COV'] ? '../lib-cov' : '../lib',
 	solr = require( libPath + '/solr'),
 	SolrError = require(libPath + '/error/solr-error'),
-	sassert = require('./sassert');
+	sassert = require('./sassert'),
+	versionUtils = require('./../lib/utils/version');
 
 // Test suite
 var config = figc(__dirname + '/config.json');
@@ -35,7 +36,11 @@ describe('Client',function(){
 			var stop = new Date();
 			stop.setDate(stop.getDate() - 1);
 			var request =  client.deleteByRange(field,start,stop,{softCommit : true},function(err,data){
-				assert.equal(request.path, basePath + '/update/json?softCommit=true&wt=json');
+				if(client.options.solrVersion && versionUtils.version(client.options.solrVersion) >= versionUtils.Solr4_0) {
+					assert.equal(request.path, basePath + '/update?softCommit=true&wt=json');
+				} else {
+					assert.equal(request.path, basePath + '/update/json?softCommit=true&wt=json');
+				}
 				sassert.ok(err,data);
 				done();
 			});
@@ -48,7 +53,11 @@ describe('Client',function(){
 			var stop = new Date();
 			stop.setDate(stop.getDate() - 1);
 			var request = client.deleteByRange(field,start,stop,{commitWithin : 10000},function(err,data){
-				assert.equal(request.path, basePath + '/update/json?commitWithin=10000&wt=json');
+				if(client.options.solrVersion && versionUtils.version(client.options.solrVersion) >= versionUtils.Solr4_0) {
+					assert.equal(request.path, basePath + '/update?commitWithin=10000&wt=json');
+				} else {
+					assert.equal(request.path, basePath + '/update/json?commitWithin=10000&wt=json');
+				}
 				sassert.ok(err,data);
 				done();
 			});
@@ -61,7 +70,11 @@ describe('Client',function(){
 			var stop = new Date();
 			stop.setDate(stop.getDate() - 1);
 			var request = client.deleteByRange(field,start,stop,{commit : true},function(err,data){
-				assert.equal(request.path, basePath + '/update/json?commit=true&wt=json');
+				if(client.options.solrVersion && versionUtils.version(client.options.solrVersion) >= versionUtils.Solr4_0) {
+					assert.equal(request.path, basePath + '/update?commit=true&wt=json');
+				} else {
+					assert.equal(request.path, basePath + '/update/json?commit=true&wt=json');
+				}
 				sassert.ok(err,data);
 				done();
 			});

--- a/test/facet-query-test.js
+++ b/test/facet-query-test.js
@@ -8,7 +8,8 @@ var mocha = require('mocha'),
 	libPath = process.env['SOLR_CLIENT_COV'] ? '../lib-cov' : '../lib',
 	solr = require( libPath + '/solr'),
 	SolrError = require(libPath + '/error/solr-error'),
-	sassert = require('./sassert');
+	sassert = require('./sassert'),
+	versionUtils = require('./../lib/utils/version');
 
 //TODO support all stuff describe there
 // http://wiki.apache.org/solr/SimpleFacetParameters#Retrieve_docs_with_facets_missing
@@ -63,28 +64,30 @@ describe('Client#createQuery()',function(){
 				.debugQuery();
 			client.search(query,function(err,data){
 				sassert.ok(err,data);
-				assert.deepEqual(data.responseHeader.params,
-					{
-						facet: 'true',
-						wt: 'json',
-						debugQuery: 'true',
-						q: 'title_t:test',
-						"facet.field": 'author',
- 						"facet.limit": "100",
-						"facet.method": "fc",
-						"facet.mincount": "10",
-						"facet.missing": "true",
-						"facet.offset": "5",
-						"facet.pivot": [
-							"cat",
-							"popularity"
-						],
-						"facet.pivot.mincount": "10",
-						"facet.prefix": "prefix",
-						"facet.query": "query",
-						"facet.sort": "field desc"
-					}
-        		);
+				var validationJSON = {
+					facet: 'true',
+					wt: 'json',
+					debugQuery: 'true',
+					q: 'title_t:test',
+					"facet.field": 'author',
+					"facet.limit": "100",
+					"facet.method": "fc",
+					"facet.mincount": "10",
+					"facet.missing": "true",
+					"facet.offset": "5",
+					"facet.prefix": "prefix",
+					"facet.query": "query",
+					"facet.sort": "field desc"
+				};
+				if(client.options.solrVersion && versionUtils.version(client.options.solrVersion) >= versionUtils.Solr4_0) {
+					validationJSON["facet.pivot.mincount"] = "10";
+					validationJSON["facet.pivot"] = [
+						"cat",
+						"popularity"
+					];
+				}
+
+				assert.deepEqual(data.responseHeader.params, validationJSON);
 				assert.equal(data.debug.QParser,'LuceneQParser');
 				done();
 			});
@@ -132,25 +135,28 @@ describe('Client#createQuery()',function(){
 				.debugQuery();
 			client.search(query,function(err,data){
 				sassert.ok(err,data);
-				assert.deepEqual(data.responseHeader.params,
-					{
-						facet: 'true',
-						wt: 'json',
-						debugQuery: 'true',
-						q: 'title_t:test',
-						"facet.field": 'author',
- 						"facet.limit": "100",
-						"facet.method": "fc",
-						"facet.mincount": "10",
-						"facet.missing": "true",
-						"facet.offset": "5",
-						"facet.pivot": "cat",
-						"facet.pivot.mincount": "10",
-						"facet.prefix": "prefix",
-						"facet.query": "query",
-						"facet.sort": "field desc"
-					}
-        		);
+				var validationJSON = {
+					facet: 'true',
+					wt: 'json',
+					debugQuery: 'true',
+					q: 'title_t:test',
+					"facet.field": 'author',
+					"facet.limit": "100",
+					"facet.method": "fc",
+					"facet.mincount": "10",
+					"facet.missing": "true",
+					"facet.offset": "5",
+					"facet.prefix": "prefix",
+					"facet.query": "query",
+					"facet.sort": "field desc"
+				};
+
+				if(client.options.solrVersion && versionUtils.version(client.options.solrVersion) >= versionUtils.Solr4_0) {
+					validationJSON["facet.pivot"] = "cat";
+					validationJSON["facet.pivot.mincount"] = "10";
+				}
+
+				assert.deepEqual(data.responseHeader.params, validationJSON);
 				assert.equal(data.debug.QParser,'LuceneQParser');
 				done();
 			});

--- a/test/facet-query-test.js
+++ b/test/facet-query-test.js
@@ -46,7 +46,7 @@ describe('Client#createQuery()',function(){
 								,	"range": [{
 											"field": "range_field"
 										,	"start": 0.0
-										,	"end": "1000"	
+										,	"end": "1000"
 										,	"gap": "+1DAY"
 										,	"hardened": true
 										,	"other": "all"
@@ -54,9 +54,9 @@ describe('Client#createQuery()',function(){
 										}]
 								,	"pivot": {
 											"fields": ["cat", "popularity"]
-										,	"mincount": 10	
+										,	"mincount": 10
 										}
-								}
+								};
 			var query = client.createQuery()
 				.facet(facetOptions)
 				.q({ title_t : 'test'})
@@ -75,6 +75,11 @@ describe('Client#createQuery()',function(){
 						"facet.mincount": "10",
 						"facet.missing": "true",
 						"facet.offset": "5",
+						"facet.pivot": [
+							"cat",
+							"popularity"
+						],
+						"facet.pivot.mincount": "10",
 						"facet.prefix": "prefix",
 						"facet.query": "query",
 						"facet.sort": "field desc"
@@ -110,7 +115,7 @@ describe('Client#createQuery()',function(){
 								,	"range": {
 											"field": "range_field"
 										,	"start": 0.0
-										,	"end": "1000"	
+										,	"end": "1000"
 										,	"gap": "+1DAY"
 										,	"hardened": true
 										,	"other": "all"
@@ -118,9 +123,9 @@ describe('Client#createQuery()',function(){
 										}
 								,	"pivot": {
 											"fields": "cat"
-										,	"mincount": 10	
+										,	"mincount": 10
 										}
-								}
+								};
 			var query = client.createQuery()
 				.facet(facetOptions)
 				.q({ title_t : 'test'})
@@ -139,6 +144,8 @@ describe('Client#createQuery()',function(){
 						"facet.mincount": "10",
 						"facet.missing": "true",
 						"facet.offset": "5",
+						"facet.pivot": "cat",
+						"facet.pivot.mincount": "10",
 						"facet.prefix": "prefix",
 						"facet.query": "query",
 						"facet.sort": "field desc"

--- a/test/materials/schema.xml
+++ b/test/materials/schema.xml
@@ -96,8 +96,8 @@
       and back compatibility is not guaranteed.  Names with both leading and
       trailing underscores (e.g. _version_) are reserved.
    -->
-        
-   <field name="id" type="string" indexed="true" stored="true" required="true" multiValued="false" /> 
+
+   <field name="id" type="string" indexed="true" stored="true" required="true" multiValued="false" />
    <field name="sku" type="text_en_splitting_tight" indexed="true" stored="true" omitNorms="true"/>
    <field name="name" type="text_general" indexed="true" stored="true"/>
    <field name="manu" type="text_general" indexed="true" stored="true" omitNorms="true"/>
@@ -124,7 +124,7 @@
    <field name="subject" type="text_general" indexed="true" stored="true"/>
    <field name="description" type="text_general" indexed="true" stored="true"/>
    <field name="comments" type="text_general" indexed="true" stored="true"/>
-   <field name="author" type="text_general" indexed="true" stored="true"/>
+   <field name="author" type="text_general" indexed="true" stored="true" multiValued="false"/>
    <field name="keywords" type="text_general" indexed="true" stored="true"/>
    <field name="category" type="text_general" indexed="true" stored="true"/>
    <field name="resourcename" type="text_general" indexed="true" stored="true"/>

--- a/test/prepareCommit-test.js
+++ b/test/prepareCommit-test.js
@@ -8,7 +8,8 @@ var mocha = require('mocha'),
 	libPath = process.env['SOLR_CLIENT_COV'] ? '../lib-cov' : '../lib',
 	solr = require( libPath + '/solr'),
 	SolrError = require(libPath + '/error/solr-error'),
-	sassert = require('./sassert');
+	sassert = require('./sassert'),
+	versionUtils = require('./../lib/utils/version');
 
 // Test suite
 var config = figc(__dirname + '/config.json');
@@ -20,12 +21,16 @@ describe('Client',function(){
 		it('should prepare the commit',function(done){
 			var request = client.prepareCommit(function(err,data){
 				sassert.ok(err,data);
-				assert.equal(request.path, basePath + '/update/json?prepareCommit=true&wt=json');
+				if(client.options.solrVersion && versionUtils.version(client.options.solrVersion) >= versionUtils.Solr4_0) {
+					assert.equal(request.path, basePath + '/update?prepareCommit=true&wt=json');
+				} else {
+					assert.equal(request.path, basePath + '/update/json?prepareCommit=true&wt=json');
+				}
 				done();
 			});
 		});
 	});
 });
 
-// Support 
+// Support
 // http://wiki.apache.org/solr/UpdateXmlMessages?highlight=%28softCommit%29#A.22prepareCommit.22

--- a/test/softCommit-test.js
+++ b/test/softCommit-test.js
@@ -8,7 +8,8 @@ var mocha = require('mocha'),
 	libPath = process.env['SOLR_CLIENT_COV'] ? '../lib-cov' : '../lib',
 	solr = require( libPath + '/solr'),
 	SolrError = require(libPath + '/error/solr-error'),
-	sassert = require('./sassert');
+	sassert = require('./sassert'),
+	versionUtils = require('./../lib/utils/version');
 
 // Test suite
 var config = figc(__dirname + '/config.json');
@@ -20,12 +21,16 @@ describe('Client',function(){
 		it('should do a soft commit',function(done){
 			var request = client.softCommit(function(err,data){
 				sassert.ok(err,data);
-				assert.equal(request.path, basePath + '/update/json?softCommit=true&wt=json');
+				if(client.options.solrVersion && versionUtils.version(client.options.solrVersion) >= versionUtils.Solr4_0) {
+					assert.equal(request.path, basePath + '/update?softCommit=true&wt=json');
+				} else {
+					assert.equal(request.path, basePath + '/update/json?softCommit=true&wt=json');
+				}
 				done();
 			});
 		});
 	});
 });
 
-// Support 
+// Support
 // http://wiki.apache.org/solr/UpdateXmlMessages?highlight=%28softCommit%29#A.22prepareCommit.22

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -5,7 +5,9 @@
 var mocha = require('mocha'),
 	assert = require('chai').assert,
 	libPath = process.env['SOLR_CLIENT_COV'] ? '../lib-cov' : '../lib',
-	format = require( libPath + '/utils/format');
+	format = require( libPath + '/utils/format'),
+	arrayUtils = require(libPath + '/utils/array'),
+	typeUtils = require(libPath + '/utils/type');
 
 // Test suite
 
@@ -28,6 +30,67 @@ describe('format',function(){
 			var dateArray = [date];
 			var dateArrayISOify = format.dateISOify(dateArray);
 			assert.equal(dateArrayISOify[0],date.toISOString());
+		});
+	});
+});
+describe('typeUtils', function() {
+	describe('.isNumber(), strict', function() {
+		it('should detect positively a parameter that contains a primitive number', function() {
+			assert.equal(typeUtils.isNumber(0), true, '0 is a number');
+			assert.equal(typeUtils.isNumber(-1), true, '-1 is a number');
+			assert.equal(typeUtils.isNumber('-1'), true, '"-1" is a number (parseInt valid)');
+			assert.equal(typeUtils.isNumber('0'), true, '"0" is a number');
+			assert.equal(typeUtils.isNumber('1'), true, '"1" is a number');
+			assert.equal(typeUtils.isNumber('1000000'), true, '"1000000" is a number');
+			assert.equal(typeUtils.isNumber('100000000'), true, '"100000000" is a number');
+		});
+		it('should detect negatively a parameter that contains a mixed number or no number', function() {
+			assert.equal(typeUtils.isNumber('1a'), false, '"1a" is not a number (mixed number)');
+			assert.equal(typeUtils.isNumber('- 1'), false, '"- 1" is not a number (not parseInt valid)');
+			assert.equal(typeUtils.isNumber('a123'), false, '"a123" is not a number (not parseInt valid)');
+			assert.equal(typeUtils.isNumber('a'), false, '"a" is not a number (string)');
+			assert.equal(typeUtils.isNumber(''), false, '"" is not a number (string)');
+		});
+	});
+	describe('.isNumber(), non strict', function() {
+		it('should detect positively a parameter that contains a primitive and a mixed number', function() {
+			assert.equal(typeUtils.isNumber(0, false), true, '0 is a number');
+			assert.equal(typeUtils.isNumber(-1, false), true, '-1 is a number');
+			assert.equal(typeUtils.isNumber('-1', false), true, '"-1" is a number (parseInt valid)');
+			assert.equal(typeUtils.isNumber('0', false), true, '"0" is a number');
+			assert.equal(typeUtils.isNumber('1', false), true, '"1" is a number');
+			assert.equal(typeUtils.isNumber('1000000', false), true, '"1000000" is a number');
+			assert.equal(typeUtils.isNumber('100000000', false), true, '"100000000" is a number');
+			assert.equal(typeUtils.isNumber('1a', false), true, '"1" is a number (parseInt valid)');
+			assert.equal(typeUtils.isNumber('1123a', false), true, '"1123" is a number (parseInt valid)');
+		});
+		it('should detect negatively a parameter that contains no valid number', function() {
+			assert.equal(typeUtils.isNumber('- 1', false), false, '"- 1" is not a number (not parseInt valid)');
+			assert.equal(typeUtils.isNumber('a123', false), false, '"a123" is not a number (not parseInt valid)');
+			assert.equal(typeUtils.isNumber('a', false), false, '"a" is not a number (string)');
+			assert.equal(typeUtils.isNumber('', false), false, '"" is not a number (string)');
+		});
+	});
+});
+describe('array', function() {
+	describe('.toArray()', function() {
+		it('should array-ize everything', function() {
+			assert.equal(Array.isArray(arrayUtils.toArray([])), true, '[] is an array');
+			assert.equal(Array.isArray(arrayUtils.toArray('')), true, '[""] is an array');
+			assert.equal(Array.isArray(arrayUtils.toArray([{a: 123}])), true, '[{a: 123}] is an array');
+			assert.equal(Array.isArray(arrayUtils.toArray([1])), true, '[1] is an array');
+			assert.equal(Array.isArray(arrayUtils.toArray(['a'])), true, '["a"] is an array');
+			assert.equal(Array.isArray(arrayUtils.toArray([0])), true, '[0] is an array');
+			assert.equal(Array.isArray(arrayUtils.toArray([-1])), true, '[-1] is an array');
+			assert.equal(Array.isArray(arrayUtils.toArray('')), true, '[""] is an array');
+			assert.equal(Array.isArray(arrayUtils.toArray(0)), true, '[0] is an array');
+			assert.equal(Array.isArray(arrayUtils.toArray()), true, '[] is an array');
+		});
+		it('should handle null and undefined properly', function() {
+			assert.equal(arrayUtils.toArray(undefined, '')[0] === '', true, 'undefined was cleaned up as empty string');
+			assert.equal(arrayUtils.toArray(undefined)[0] === '', true, 'using the default setup, undefined was cleaned up as empty string');
+			assert.equal(arrayUtils.toArray(null, '')[0] === '', true, 'null was cleaned up as empty string');
+			assert.equal(arrayUtils.toArray(null)[0] === '', true, 'using the default setup, null was cleaned up as empty string');
 		});
 	});
 });


### PR DESCRIPTION
Some packages are getting very old. I've updated them and tested, then updated the tests to match the new requirements (mainly for bignumber.js and solr5 multi-valued constraints)