### PR TITLE
Only check options.pivot.mincount if options.pivot is available.

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -440,9 +440,10 @@ Query.prototype.facet = function(options){
        options.field.forEach(function(field) {
          self.parameters.push('facet.pivot=' + field);
        });
-     }
-     if(options.pivot.mincount) {
-       this.parameters.push('facet.pivot.mincount=' + options.pivot.mincount);
+
+       if(options.pivot.mincount) {
+         this.parameters.push('facet.pivot.mincount=' + options.pivot.mincount);
+       }
      }
    }
 


### PR DESCRIPTION
Avoid
```TypeError: Cannot read property 'mincount' of undefined at Query.facet (.../node_modules/solr-client/lib/query.js:444:22)```