### PR TITLE
URI encode the cursorMark value before use

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -171,7 +171,7 @@ Query.prototype.rows = function(rows){
 Query.prototype.cursorMark = function(mark){
    var self = this;
    mark = mark || "*";
-   var parameter = 'cursorMark=' + mark ;
+   var parameter = 'cursorMark=' + encodeURIComponent(mark);
    this.parameters.push(parameter);
    return self;
 }


### PR DESCRIPTION
URI encoding needed because cursorMark raw value can contain characters not allowed without uri encoding.  Closes #165