### PR TITLE
Add support for ipv6 when resolving host/hostname

### DIFF
--- a/lib/solr.js
+++ b/lib/solr.js
@@ -41,12 +41,13 @@ exports.createClient = createClient;
  * @param {Boolean} [bigint=false] - if true JSONbig serializer/deserializer will be used instead
  *                                    of JSON native serializer/deserializer
  * @param solrVersion ['3.2', '4.0', '5.0', '5.1'], check lib/utils/version.js for full reference
+ * @param {Number} [ipVersion=4] - pass it to http/https lib's "family" option
  *
  * @return {Client}
  * @api public
  */
 
-function createClient(host, port, core, path, agent, secure, bigint, solrVersion){
+function createClient(host, port, core, path, agent, secure, bigint, solrVersion, ipVersion){
   var options = (typeof host === 'object') ? host : {
       host : host,
       port : port,
@@ -55,7 +56,8 @@ function createClient(host, port, core, path, agent, secure, bigint, solrVersion
       agent : agent,
       secure : secure,
       bigint : bigint,
-      solrVersion: solrVersion
+      solrVersion: solrVersion,
+      ipVersion: ipVersion == 6 ? 6 : 4
    };
   return new Client(options);
 }
@@ -73,6 +75,7 @@ function createClient(host, port, core, path, agent, secure, bigint, solrVersion
  * @param {Boolean} [options.secure=false] - if true HTTPS will be used instead of HTTP
  * @param {Boolean} [options.bigint=false] - if true JSONbig serializer/deserializer will be used instead
  *                                    of JSON native serializer/deserializer
+ * @param {Number} [ipVersion=4] - pass it to http/https lib's "family" option
  *
  * @return {Client}
  * @api private
@@ -88,7 +91,8 @@ function Client(options){
       secure : options.secure || false,
       bigint : options.bigint || false,
       get_max_request_entity_size: options.get_max_request_entity_size || false,
-      solrVersion: options.solrVersion || versionUtils.Solr3_2
+      solrVersion: options.solrVersion || versionUtils.Solr3_2,
+      ipVersion: options.ipVersion == 6 ? 6 : 4
    };
 
    // Default paths of all request handlers
@@ -513,7 +517,8 @@ Client.prototype.update = function(data,options,callback){
       secure : this.options.secure,
       bigint : this.options.bigint,
       authorization : this.options.authorization,
-      agent : this.options.agent
+      agent : this.options.agent,
+      ipVersion : this.options.ipVersion
    };
    return postJSON(params,callback);
 }
@@ -630,7 +635,8 @@ Client.prototype.get = function(handler,query,callback){
          secure: this.options.secure,
          bigint: this.options.bigint,
          authorization: this.options.authorization,
-         agent: this.options.agent
+         agent: this.options.agent,
+         ipVersion: this.options.ipVersion
       };
       return getJSON(params, callback);
    } else {
@@ -685,7 +691,8 @@ Client.prototype.post = function(handler,query,callback){
       secure : this.options.secure,
       bigint : this.options.bigint,
       authorization : this.options.authorization,
-      agent : this.options.agent
+      agent : this.options.agent,
+      ipVersion : this.options.ipVersion
    };
    return postForm(params,callback);
 }
@@ -804,7 +811,8 @@ function postJSON(params,callback){
       port : params.port,
       method : 'POST',
       headers : headers,
-      path : params.fullPath
+      path : params.fullPath,
+      family : params.ipversion
    };
 
    if(params.agent !== undefined){
@@ -860,7 +868,8 @@ function postForm(params,callback){
       port : params.port,
       method : 'POST',
       headers : headers,
-      path : params.fullPath
+      path : params.fullPath,
+      family : params.ipVersion
    };
 
    if(params.agent !== undefined){
@@ -909,7 +918,8 @@ function getJSON(params,callback){
       host : params.host,
       port : params.port,
       path : params.fullPath,
-      headers : headers
+      headers : headers,
+      family: params.ipVersion
    };
 
    if(params.agent !== undefined){


### PR DESCRIPTION
There was no way of setting the "family" option for http.request() which is necesary when speaking
with a server that only responds on ipv6.
The new option "ipVersion" is now passed to http/https