### PR TITLE
POST fails when the parameters are too long.

### DIFF
--- a/lib/solr.js
+++ b/lib/solr.js
@@ -668,9 +668,9 @@ Client.prototype.post = function(handler,query,callback){
    var pathArray;
 
    if(handler != 'admin/collections'){
-      pathArray = [this.options.path,this.options.core,handler + '?' + parameters + '&wt=json'];
+      pathArray = [this.options.path,this.options.core,handler + '?wt=json'];
    } else {
-      pathArray = [this.options.path,handler + '?' + parameters + '&wt=json'];
+      pathArray = [this.options.path,handler + '?wt=json'];
    }
 
    var fullPath = pathArray.filter(function(element){


### PR DESCRIPTION
When doing a POST request, the parameters are sent appended to the url as well. If the url is too large (e.g. over jetty's default 8192) then the request will fail with a "414 - Request-URI Too Large".