### PR TITLE
fix(Facet.Pivot): Only attempt to apply pivot.mincount if pivot is defined

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -440,9 +440,10 @@ Query.prototype.facet = function(options){
        options.field.forEach(function(field) {
          self.parameters.push('facet.pivot=' + field);
        });
-     }
-     if(options.pivot.mincount) {
-       this.parameters.push('facet.pivot.mincount=' + options.pivot.mincount);
+
+       if(options.pivot.mincount) {
+         this.parameters.push('facet.pivot.mincount=' + options.pivot.mincount);
+       }
      }
    }
 


### PR DESCRIPTION
The current code will blow up if you have 5.x features turned on but no pivots specified.

I had difficulty setting up the tests because I don't have much operational knowledge of solr (I'm just a consumer), but I'm guessing there's no code coverage for this.