### PR TITLE
For post requests, do not include the query string in the URL 

### DIFF
--- a/lib/solr.js
+++ b/lib/solr.js
@@ -668,7 +668,7 @@ Client.prototype.post = function(handler,query,callback){
    var pathArray;
 
    if(handler != 'admin/collections'){
-      pathArray = [this.options.path,this.options.core,handler + '?' + parameters + '&wt=json'];
+      pathArray = [this.options.path,this.options.core,handler + '?wt=json'];
    } else {
       pathArray = [this.options.path,handler + '?' + parameters + '&wt=json'];
    }


### PR DESCRIPTION
This causes 414 errors if the query string is too long.