### PR TITLE
* escaping fl parameter in Query

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -272,9 +272,9 @@ Query.prototype.restrict = function(fields){
    var self = this;
    var parameter = 'fl=';
    if(typeof(fields) === 'string'){
-      parameter += fields;
+      parameter += encodeURIComponent(fields);
    }else{
-      parameter += fields.join(',');
+      parameter += encodeURIComponent(fields.join(','));
    }
    this.parameters.push(parameter);
    return self;

--- a/test/core-query-test.js
+++ b/test/core-query-test.js
@@ -108,6 +108,19 @@ describe('Client#createQuery',function(){
 			});
 		});
 
+		it('escapes fl parameter',function(done){
+			// if it's not escaped correctly, SOLR returns HTTP 400
+			var query = client.createQuery()
+				.q("*:*").fl(['id', 'score', 'found_words:exists(query({!v=\'name:word\'}))']);
+			client.search(query, function(err, data){
+				sassert.ok(err, data);
+				assert.deepEqual(data.responseHeader.params,
+						{ q: "*:*", fl: "id,score,found_words:exists(query({!v='name:word'}))"
+            , wt: 'json'});
+				done();
+			});
+		});
+
 		it('query with deftype',function(done){
 
 			var query = client.createQuery()


### PR DESCRIPTION
When using specific syntax of fl, to add dynamic fields in result (that are not fields in schema), fl parameter must be escaped correctly. Otherwise SOLR returns HTTP error 400
