### PR TITLE
Update request dependency to current version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "duplexer": "~0.1.1",
     "httperror": "~0.2.3",
     "json-bigint": "~0.1.4",
-    "request": "~2.63.0"
+    "request": "~2.81.0"
   },
   "devDependencies": {
     "chai": "~3.3.0",


### PR DESCRIPTION
Previous version has a known security vulnerability: https://nodesecurity.io/advisories/309

This in turn causes Node Security Platform's checks to fail for anything that depends on solr-client ([example](https://nodesecurity.io/orgs/ibm-watson/projects/4300a2e8-88b0-4b36-b9e0-80d6de40929f/435))