### PR TITLE
Provide raw solr response when JSON.parse fails

### DIFF
--- a/lib/solr.js
+++ b/lib/solr.js
@@ -995,6 +995,7 @@ function handleJSONResponse(request, bigint, callback){
                data = pickJSON(bigint).parse(text);
             }catch(error){
                err = error;
+               err.body = text;
             }finally{
                if(callback)  callback(err,data);
             }


### PR DESCRIPTION
A customer reported that when uploading hundreds of thousands of documents, a few could hit an "unexpected in of json" error here. This change adds the actual response text to the error object at error.body to aid in debugging. It should have no effect on normal usage.