### PR TITLE
 # 195 support http and https proxy

### DIFF
--- a/lib/solr.js
+++ b/lib/solr.js
@@ -512,11 +512,8 @@ Client.prototype.update = function(data,options,callback){
                               .join('/');
 
    var params = {
-      host : this.options.host,
-      port : this.options.port,
-      fullPath : fullPath,
+      url : (this.options.secure? "https" : "http") + '://' + this.options.host +':' + this.options.port + fullPath,
       json : json,
-      secure : this.options.secure,
       bigint : this.options.bigint,
       authorization : this.options.authorization,
       agent : this.options.agent,
@@ -649,10 +646,7 @@ Client.prototype.get = function(handler,query,callback){
 
    if (this.options.get_max_request_entity_size === false || approxUrlLength <= this.options.get_max_request_entity_size) {
       var params = {
-         host: this.options.host,
-         port: this.options.port,
-         fullPath: fullPath,
-         secure: this.options.secure,
+         url : (this.options.secure? "https" : "http") + '://' + this.options.host +':' + this.options.port + fullPath,
          bigint: this.options.bigint,
          authorization: this.options.authorization,
          agent: this.options.agent,
@@ -704,11 +698,8 @@ Client.prototype.post = function(handler,query,callback){
               }).join('/');
 
    var params = {
-      host : this.options.host,
-      port : this.options.port,
-      fullPath : fullPath,
+      url : (this.options.secure? "https" : "http") + '://' + this.options.host +':' + this.options.port + fullPath,
       params : parameters,
-      secure : this.options.secure,
       bigint : this.options.bigint,
       authorization : this.options.authorization,
       agent : this.options.agent,
@@ -827,11 +818,8 @@ function postJSON(params,callback){
       headers['authorization'] = params.authorization;
    }
    var options = {
-      host : params.host,
-      port : params.port,
-      method : 'POST',
+      url: params.url,
       headers : headers,
-      path : params.fullPath,
       family : params.ipversion
    };
 
@@ -839,18 +827,18 @@ function postJSON(params,callback){
       options.agent = params.agent;
    }
 
-   var request = pickProtocol(params.secure).request(options);
+   var postRequest = request.post(options);
 
-   request.on('response', handleJSONResponse(request, params.bigint, callback));
+   postRequest.on('response', handleJSONResponse(postRequest, params.bigint, callback));
 
-   request.on('error',function onError(err){
+   postRequest.on('error',function onError(err){
       if (callback) callback(err,null);
    });
 
-   request.write(params.json);
-   request.end();
+   postRequest.write(params.json);
+   postRequest.end();
 
-   return request;
+   return postRequest;
 };
 
 /**
@@ -884,11 +872,8 @@ function postForm(params,callback){
       headers['authorization'] = params.authorization;
    }
    var options = {
-      host : params.host,
-      port : params.port,
-      method : 'POST',
+      url: params.url,
       headers : headers,
-      path : params.fullPath,
       family : params.ipVersion
    };
 
@@ -896,18 +881,18 @@ function postForm(params,callback){
       options.agent = params.agent;
    }
 
-   var request = pickProtocol(params.secure).request(options);
+   var postRequest = request.post(options);
 
-   request.on('response', handleJSONResponse(request, params.bigint, callback));
+   postRequest.on('response', handleJSONResponse(postRequest, params.bigint, callback));
 
-   request.on('error',function onError(err){
+   postRequest.on('error',function onError(err){
       if (callback) callback(err,null);
    });
 
-   request.write(params.params);
-   request.end();
+   postRequest.write(params.params);
+   postRequest.end();
 
-   return request;
+   return postRequest;
 };
 
 /**
@@ -935,9 +920,7 @@ function getJSON(params,callback){
       'accept' : 'application/json; charset=utf-8'
    };
    var options = {
-      host : params.host,
-      port : params.port,
-      path : params.fullPath,
+      url : params.url,
       headers : headers,
       family: params.ipVersion
    };
@@ -953,14 +936,14 @@ function getJSON(params,callback){
       options.headers = headers;
    }
 
-   var request = pickProtocol(params.secure).get(options);
+   var getRequest = request.get(options);
 
-   request.on('response', handleJSONResponse(request, params.bigint, callback));
+   getRequest.on('response', handleJSONResponse(getRequest, params.bigint, callback));
 
-   request.on('error',function(err){
+   getRequest.on('error',function(err){
       if (callback) callback(err,null);
    });
-   return request;
+   return getRequest;
 };
 
 /**


### PR DESCRIPTION
I replaced the module request for the modules http/https to support requests to a solr via http and https proxy. [The module request has built-in proxy support](https://github.com/request/request#proxies).   It uses the proxy conditions set in process.env.http_proxy, process.env.https_proxy and process.env.no_proxy.

I'm sorry  for not adding automated tests under http proxy because I couldn't find any simple ways to create automated-test via a proxy server.