### PR TITLE
update escaped special characters: add /

### DIFF
--- a/lib/utils/format.js
+++ b/lib/utils/format.js
@@ -128,7 +128,7 @@ function stringifyPrimitive(v) {
   */
 
 function escapeSpecialChars(s){
-  return s.replace(/([\+\-!\(\)\{\}\[\]\^"~\*\?:\\])/g, function(match) {
+  return s.replace(/([\+\-!\(\)\{\}\[\]\^"~\*\?:\\\/])/g, function(match) {
     return '\\' + match;
   })
   .replace(/&&/g, '\\&\\&')

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "duplexer": "~0.1.1",
     "httperror": "~0.2.3",
     "json-bigint": "~0.1.4",
-    "request": "~2.81.0"
+    "request": "^2.81.0"
   },
   "devDependencies": {
     "chai": "~3.3.0",


### PR DESCRIPTION
Lucene added `/` as special character in version 4.0.0
http://lucene.apache.org/core/4_0_0/queryparser/org/apache/lucene/queryparser/classic/package-summary.html#Escaping_Special_Characters

Fix Issue #173