### PR TITLE
Port should be optional #219

### DIFF
--- a/lib/solr.js
+++ b/lib/solr.js
@@ -69,7 +69,7 @@ function createClient(host, port, core, path, agent, secure, bigint, solrVersion
  *
  * @param {Object} options - set of options used to request the Solr server
  * @param {String} options.host - IP address or host address of the Solr server
- * @param {Number|String} options.port - port of the Solr server
+ * @param {Number|String} options.port - port of the Solr server, 0 to be ignored by HTTP agent in case of using API endpoint.
  * @param {String} options.core - name of the Solr core requested
  * @param {String} options.path - root path of all requests
  * @param {http.Agent} [options.agent] - HTTP Agent which is used for pooling sockets used in HTTP(s) client requests
@@ -85,7 +85,7 @@ function createClient(host, port, core, path, agent, secure, bigint, solrVersion
 function Client(options){
    this.options = {
       host : options.host || '127.0.0.1',
-      port : options.port || '8983',
+      port : options.port === 0 ? 0 : options.port || '8983',
       core : options.core || '',
       path : options.path || '/solr',
       agent : options.agent,


### PR DESCRIPTION
Allow port to be ignored by HTTP agents, by setting value to 0. 
https://github.com/lbdremy/solr-node-client/issues/219