### PR TITLE
added fq() for passing in an object or multiple filters

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -268,6 +268,34 @@ Query.prototype.matchFilter = function (field, value) {
 };
 
 /**
+ * wrapper function for matchFilter, accepting either an object with `field` and `value` properties
+ * or an array containing such objects to be mapped on matchFilter
+ *
+ * @param {Object|Array} filters - Object or an array of objects with `field` and `value` properties
+ *
+ * @return {Query}
+ * 
+ * @throws {Error}
+ * @api public
+ *
+ * @example
+ * var query = client.createQuery();
+ * query.q({ '*' : '*' }).fq({field: 'id', value: 100})
+ * query.q({ '*' : '*' }).fq([{field: 'id', value: 100}, {field: 'name', value: 'John'}])
+ */
+ Query.prototype.fq = function (filters) {
+  const self = this
+  if (filters instanceof Array) {
+    filters.map(f => this.matchFilter(f.field, f.value))
+    return self
+  }
+  if (filters instanceof Object) return this.matchFilter(filters.field, filters.value)
+  else {
+    throw new Error('unknown type for filter in fq()')
+  }
+}
+
+/**
  * Specify a set of fields to return.
  *
  * @param {String|Array} field - field name

--- a/lib/query.js
+++ b/lib/query.js
@@ -285,7 +285,7 @@ Query.prototype.matchFilter = function (field, value) {
  */
  Query.prototype.fq = function (filters) {
   const self = this
-  if (filters instanceof Array) {
+  if (Array.isArray(filters)) {
     filters.map(f => this.matchFilter(f.field, f.value))
     return self
   }

--- a/test/core-query-test.js
+++ b/test/core-query-test.js
@@ -266,5 +266,43 @@ describe('Client#createQuery', function () {
         done();
       });
     });
+
+    it('query with multiple match-filters', function (done) {
+      const query = client
+        .createQuery()
+        .q('*:*')
+        .fq([{field: 'id', value: '19700506.173.85'}, {field: 'title', value: 'testvalue'}])
+        .debugQuery();
+
+      client.search(query, function (err, data) {
+        sassert.ok(err, data);
+        assert.deepEqual(data.responseHeader.params, {
+          debugQuery: 'true',
+          q: '*:*',
+          fq: ['id:19700506.173.85', 'title:testvalue'],
+          wt: 'json',
+        });
+        done();
+      });
+    });
+
+    it('query with object match-filter', function (done) {
+      const query = client
+        .createQuery()
+        .q('*:*')
+        .fq({field: 'id', value: '19700506.173.85'})
+        .debugQuery();
+
+      client.search(query, function (err, data) {
+        sassert.ok(err, data);
+        assert.deepEqual(data.responseHeader.params, {
+          debugQuery: 'true',
+          q: '*:*',
+          fq: 'id:19700506.173.85',
+          wt: 'json',
+        });
+        done();
+      });
+    });
   });
 });


### PR DESCRIPTION
this feature wraps the matchFilter() on the query to be able to pass in either an object with 'field' and 'value' properties or an array with such objects.
test cases are contained within the given tests.

regards, ni-do