### PR TITLE
Bugfix & refactor (inline) `getJSON` function.

### DIFF
--- a/lib/solr.js
+++ b/lib/solr.js
@@ -919,14 +919,13 @@ function postForm(params, callback) {
  */
 
 function getJSON(params, callback) {
-  let headers = {
-    accept: 'application/json; charset=utf-8',
-  };
   let options = {
     host: params.host,
     port: params.port,
     path: params.fullPath,
-    headers: headers,
+    headers: {
+      accept: 'application/json; charset=utf-8',
+    },
     family: params.ipVersion,
   };
 
@@ -939,10 +938,10 @@ function getJSON(params, callback) {
   }
 
   if (params.authorization) {
-    headers = {
+    // BUG: Previous values for options.headers are not considered.
+    options.headers = {
       authorization: params.authorization,
     };
-    options.headers = headers;
   }
 
   const request = pickProtocol(params.secure).get(options);

--- a/lib/solr.js
+++ b/lib/solr.js
@@ -938,10 +938,7 @@ function getJSON(params, callback) {
   }
 
   if (params.authorization) {
-    // BUG: Previous values for options.headers are not considered.
-    options.headers = {
-      authorization: params.authorization,
-    };
+    options.headers.authorization = params.authorization;
   }
 
   const request = pickProtocol(params.secure).get(options);

--- a/lib/solr.js
+++ b/lib/solr.js
@@ -704,27 +704,40 @@ Client.prototype.get = function (handler, query, callback) {
     (this.options.port + '').length +
     Buffer.byteLength(fullPath); // Buffer (10) accounts for protocol and special characters like ://, port colon, and initial slash etc
 
-  if (
-    this.options.get_max_request_entity_size === false ||
-    approxUrlLength <= this.options.get_max_request_entity_size
-  ) {
-    const params = {
-      host: this.options.host,
-      port: this.options.port,
-      fullPath: fullPath,
-      secure: this.options.secure,
-      bigint: this.options.bigint,
-      authorization: this.options.authorization,
-      agent: this.options.agent,
-      ipVersion: this.options.ipVersion,
-      request: this.options.request,
-    };
-
-    return getJSON(params, callback);
-  } else {
+  if (!(this.options.get_max_request_entity_size === false ||
+    approxUrlLength <= this.options.get_max_request_entity_size)) {
     // Funnel this through a POST because it's too large
     return this.post(handler, query, callback);
   }
+
+  const requestOptions = {
+    host: this.options.host,
+    port: this.options.port,
+    path: fullPath,
+    headers: {
+      accept: 'application/json; charset=utf-8',
+    },
+    family: this.options.ipVersion,
+
+    // Allow these to override (not merge with) previous values.
+    ...this.options.request,
+  };
+  if (this.options.agent) {
+    requestOptions.agent = this.options.agent;
+  }
+  if (this.options.authorization) {
+    requestOptions.headers.authorization = params.authorization;
+  }
+
+  const request = pickProtocol(params.secure).get(requestOptions);
+  request.on('response', handleJSONResponse(
+    request, params.bigint, callback));
+  request.on('error', function(err) {
+    if (callback) {
+      callback(err, null);
+    }
+  });
+  return request;
 };
 
 /**
@@ -894,60 +907,6 @@ function postForm(params, callback) {
   request.write(params.params);
   request.end();
 
-  return request;
-}
-
-/**
- * HTTP GET request.  Send a query command to the Solr server (query)
- *
- * @param {Object} params
- * @param {String} params.host - IP address or host address of the Solr server
- * @param {Number|String} params.port - port of the Solr server
- * @param {String} params.core - name of the Solr core requested
- * @param {String} params.authorization - value of the authorization header
- * @param {String} params.fullPath - full path of the request, contains query parameters
- * @param {Boolean} params.secure -
- * @param {Boolean} params.bigint -
- * @param {http.Agent} [params.agent] -
- * @param {Object} params.request - request options
- * @param {Function} callback(err,obj) - a function executed when the Solr server responds or an error occurs
- * @param {Error} callback().err
- * @param {Object} callback().obj - JSON response sent by the Solr server deserialized
- *
- * @return {http.ClientRequest}
- * @api private
- */
-
-function getJSON(params, callback) {
-  let options = {
-    host: params.host,
-    port: params.port,
-    path: params.fullPath,
-    headers: {
-      accept: 'application/json; charset=utf-8',
-    },
-    family: params.ipVersion,
-  };
-
-  if (params.request) {
-    options = Object.assign(options, params.request);
-  }
-
-  if (params.agent !== undefined) {
-    options.agent = params.agent;
-  }
-
-  if (params.authorization) {
-    options.headers.authorization = params.authorization;
-  }
-
-  const request = pickProtocol(params.secure).get(options);
-
-  request.on('response', handleJSONResponse(request, params.bigint, callback));
-
-  request.on('error', function (err) {
-    if (callback) callback(err, null);
-  });
   return request;
 }
 


### PR DESCRIPTION
This is an alternative to https://github.com/lbdremy/solr-node-client/pull/244

Closes https://github.com/lbdremy/solr-node-client/issues/243

Makes progress towards https://github.com/lbdremy/solr-node-client/issues/125 by making the code that builds the options for GET requests easier to read.