### PR TITLE
Drop support for deprecated Node versions

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x, 14.x, 12.x, 10.x]
+        node-version: [16.x, 14.x, 12.x]
 
     steps:
       - name: Checkout Repository

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x, 14.x, 12.x, 10.x, 8.x, 6.x]
+        node-version: [16.x, 14.x, 12.x, 10.x]
 
     steps:
       - name: Checkout Repository

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ npm install --save solr-client
 
 ## Documentation
 
-Node.js version 10+ is supported.
+Node.js version 12+ is supported.
 Solr versions 3-8 are supported.
 
 * See the [official documentation](https://lbdremy.github.io/solr-node-client/) for more details.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ npm install --save solr-client
 
 ## Documentation
 
-Node.js version 6+ is supported.
+Node.js version 10+ is supported.
 Solr versions 3-8 are supported.
 
 * See the [official documentation](https://lbdremy.github.io/solr-node-client/) for more details.

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/lbdremy/solr-node-client"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 10"
   },
   "dependencies": {
     "bluebird": "^3.7.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/lbdremy/solr-node-client"
   },
   "engines": {
-    "node": ">= 10"
+    "node": ">= 12"
   },
   "dependencies": {
     "bluebird": "^3.7.2",


### PR DESCRIPTION
This enables us to use up-to-date libraries and modern JavaScript syntax.