### PR TITLE
Allow Github Actions to be triggered manually

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     branches:
       - master
+  workflow_dispatch: { }
 
 jobs:
   build:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     branches:
       - master
+  workflow_dispatch: { }
 
 jobs:
   build:

--- a/.github/workflows/solr-legacy.yml
+++ b/.github/workflows/solr-legacy.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     branches:
       - master
+  workflow_dispatch: { }
 
 jobs:
   build:


### PR DESCRIPTION
This will help a lot with determining why tests are failing in CI but not locally. This way, we don't have to create hundreds of PRs just to get CI running on various commits.