### PR TITLE
Single level of abstraction / Better separation of concerns in query methods

### DIFF
--- a/examples/get.js
+++ b/examples/get.js
@@ -8,7 +8,7 @@ const solr = require('../lib/solr');
 const client = solr.createClient();
 
 const query = 'q=id:UTF8TEST&mlt.fl=manu,cat&mlt.mindf=1&mlt.mintf=1';
-client.get('mlt', query, function (err, obj) {
+client.doQuery('mlt', query, function (err, obj) {
   if (err) {
     console.log(err);
   } else {

--- a/lib/solr.ts
+++ b/lib/solr.ts
@@ -221,7 +221,7 @@ export class Client {
       query['ids'] = ids.join(',');
     }
 
-    return this.get(this.REAL_TIME_GET_HANDLER, query, callback);
+    return this.doQuery(this.REAL_TIME_GET_HANDLER, query, callback);
   }
 
   /**
@@ -260,7 +260,7 @@ export class Client {
 
     const handler = this.UPDATE_HANDLER + '/' + options.format.toLowerCase();
     const query = querystring.stringify(options.parameters);
-    return this.get(handler, query, callback);
+    return this.doQuery(handler, query, callback);
   }
 
   /**
@@ -640,7 +640,7 @@ export class Client {
     query: Query | Record<string, any> | string,
     callback: CallbackFn
   ): ClientRequest {
-    return this.get(this.SELECT_HANDLER, query, callback);
+    return this.doQuery(this.SELECT_HANDLER, query, callback);
   }
 
   /**
@@ -658,7 +658,7 @@ export class Client {
     collection: Collection | Record<string, any> | string,
     callback: CallbackFn
   ): ClientRequest {
-    return this.get(this.COLLECTIONS_HANDLER, collection, callback);
+    return this.doQuery(this.COLLECTIONS_HANDLER, collection, callback);
   }
 
   /**
@@ -691,7 +691,7 @@ export class Client {
    */
 
   spell(query: Query, callback: CallbackFn): ClientRequest {
-    return this.get(this.SPELL_HANDLER, query, callback);
+    return this.doQuery(this.SPELL_HANDLER, query, callback);
   }
 
   /**
@@ -712,7 +712,7 @@ export class Client {
     query: Query | Record<string, any> | string,
     callback: CallbackFn
   ) {
-    return this.get(this.TERMS_HANDLER, query, callback);
+    return this.doQuery(this.TERMS_HANDLER, query, callback);
   }
 
   /**
@@ -726,7 +726,7 @@ export class Client {
    * @param callback
    *   A function to execute when the Solr server responds or an error occurs.
    */
-  get(
+  doQuery(
     handler: string,
     query: Collection | Query | Record<string, any> | string | CallbackFn,
     callback?: CallbackFn
@@ -944,7 +944,7 @@ export class Client {
    */
 
   ping(callback: CallbackFn) {
-    return this.get(this.ADMIN_PING_HANDLER, callback);
+    return this.doQuery(this.ADMIN_PING_HANDLER, callback);
   }
 
   createSchemaField(

--- a/lib/solr.ts
+++ b/lib/solr.ts
@@ -278,8 +278,7 @@ export class Client {
       this.options.core,
       this.UPDATE_JSON_HANDLER +
         '?' +
-        querystring.stringify(options) +
-        '&wt=json',
+        querystring.stringify({ ...options, wt: 'json' }),
     ]
       .filter(function (element) {
         return element;
@@ -575,8 +574,7 @@ export class Client {
       this.options.core,
       this.UPDATE_JSON_HANDLER +
         '?' +
-        querystring.stringify(options) +
-        '&wt=json',
+        querystring.stringify({ ...options, wt: 'json' }),
     ]
       .filter(function (element) {
         return element;

--- a/lib/solr.ts
+++ b/lib/solr.ts
@@ -128,6 +128,25 @@ export class Client {
   }
 
   /**
+   * Construct the full path to the given "handler".
+   *
+   * @param handler
+   *   Relative URL path for the solr handler.
+   *
+   * @returns
+   *   Full URL to the handler.
+   */
+  private getFullHandlerPath(handler: string): string {
+    let pathArray;
+    if (handler === this.COLLECTIONS_HANDLER) {
+      pathArray = [this.options.path, handler];
+    } else {
+      pathArray = [this.options.path, this.options.core, handler];
+    }
+    return pathArray.filter((e) => e).join('/');
+  }
+
+  /**
    * Create credential using the basic access authentication method
    * @api public
    */
@@ -569,17 +588,10 @@ export class Client {
     }
 
     const json = pickJSON(this.options.bigint).stringify(data);
-    const fullPath = [
-      this.options.path,
-      this.options.core,
-      this.UPDATE_JSON_HANDLER +
-        '?' +
-        querystring.stringify({ ...queryParameters, wt: 'json' }),
-    ]
-      .filter(function (element) {
-        return element;
-      })
-      .join('/');
+    const fullPath =
+      this.getFullHandlerPath(this.UPDATE_JSON_HANDLER) +
+      '?' +
+      querystring.stringify({ ...queryParameters, wt: 'json' });
 
     const requestOptions: RequestOptions = {
       host: this.options.host,
@@ -740,23 +752,9 @@ export class Client {
       // query is a string.
       parameters += query;
     }
-    let pathArray;
 
-    if (handler != 'admin/collections') {
-      pathArray = [
-        this.options.path,
-        this.options.core,
-        handler + '?' + parameters + '&wt=json',
-      ];
-    } else {
-      pathArray = [this.options.path, handler + '?' + parameters + '&wt=json'];
-    }
-
-    const fullPath = pathArray
-      .filter(function (element) {
-        return element;
-      })
-      .join('/');
+    const fullPath =
+      this.getFullHandlerPath(handler) + '?' + parameters + '&wt=json';
 
     const approxUrlLength =
       10 +
@@ -970,7 +968,7 @@ export class Client {
       cb(undefined, result);
     };
 
-    const fullPath = `${this.options.path}/${this.options.core}/schema`;
+    const fullPath = this.getFullHandlerPath('schema');
 
     const requestOptions: RequestOptions = {
       host: this.options.host,

--- a/lib/solr.ts
+++ b/lib/solr.ts
@@ -147,6 +147,81 @@ export class Client {
   }
 
   /**
+   * Common function for all HTTP requests.
+   *
+   * @param path
+   *   Full URL for the request.
+   * @param method
+   *   HTTP method, like "GET" or "POST".
+   * @param body
+   *   Optional data for the request body.
+   * @param bodyContentType
+   *   Optional content type for the request body.
+   * @param acceptContentType
+   *   The expected content type of the response.
+   * @param callback
+   *   The function to call when done.
+   */
+  private doRequest(
+    path: string,
+    method: string,
+    body: string | null,
+    bodyContentType: string | null,
+    acceptContentType: string,
+    callback?: CallbackFn
+  ): ClientRequest {
+    const requestOptions: RequestOptions = {
+      host: this.options.host,
+      port: this.options.port,
+      headers: {},
+      family: this.options.ipVersion,
+
+      // Allow these to override (not merge with) previous values.
+      ...this.options.request,
+
+      method,
+      path,
+    };
+
+    // Now set options that the user should not be able to override.
+    if (!requestOptions.headers) {
+      requestOptions.headers = {};
+    }
+    requestOptions.headers.accept = acceptContentType;
+    if (method === 'POST') {
+      if (bodyContentType) {
+        requestOptions.headers['content-type'] = bodyContentType;
+      }
+      if (body) {
+        requestOptions.headers['content-length'] = Buffer.byteLength(body);
+      }
+    }
+    if (this.options.authorization) {
+      requestOptions.headers.authorization = this.options.authorization;
+    }
+    if (this.options.agent) {
+      requestOptions.agent = this.options.agent;
+    }
+
+    // Perform the request and handle results.
+    const request = pickProtocol(this.options.secure).request(requestOptions);
+    request.on(
+      'response',
+      handleJSONResponse(request, this.options.bigint, callback)
+    );
+    request.on('error', function onError(err) {
+      if (callback) {
+        callback(err, null);
+      }
+    });
+    if (body) {
+      request.write(body);
+    }
+    request.end();
+    return request;
+  }
+
+  /**
    * Create credential using the basic access authentication method
    * @api public
    */
@@ -587,52 +662,20 @@ export class Client {
       queryParameters = {};
     }
 
-    const json = pickJSON(this.options.bigint).stringify(data);
-    const fullPath =
-      this.getFullHandlerPath(this.UPDATE_JSON_HANDLER) +
-      '?' +
-      querystring.stringify({ ...queryParameters, wt: 'json' });
-
-    const requestOptions: RequestOptions = {
-      host: this.options.host,
-      port: this.options.port,
-      method: 'POST',
-      headers: {
-        'content-type': 'application/json; charset=utf-8',
-        'content-length': Buffer.byteLength(json),
-        accept: 'application/json; charset=utf-8',
-      },
-      path: fullPath,
-      family: this.options.ipVersion,
-
-      // Allow these to override (not merge with) previous values.
-      ...this.options.request,
-    };
-    if (this.options.agent) {
-      requestOptions.agent = this.options.agent;
-    }
-    if (this.options.authorization) {
-      if (!requestOptions.headers) {
-        requestOptions.headers = {};
-      }
-      requestOptions.headers.authorization = this.options.authorization;
-    }
-
-    const request = pickProtocol(this.options.secure).request(requestOptions);
-    request.on(
-      'response',
-      handleJSONResponse(request, this.options.bigint, callback)
-    );
-    request.on('error', function onError(err) {
-      if (callback) {
-        callback(err, null);
-      }
+    const path = this.getFullHandlerPath(this.UPDATE_JSON_HANDLER);
+    const queryString = querystring.stringify({
+      ...queryParameters,
+      wt: 'json',
     });
 
-    request.write(json);
-    request.end();
-
-    return request;
+    return this.doRequest(
+      `${path}?${queryString}`,
+      'POST',
+      pickJSON(this.options.bigint).stringify(data),
+      'application/json',
+      'application/json; charset=utf-8',
+      callback
+    );
   }
 
   /**
@@ -741,154 +784,48 @@ export class Client {
     query: Collection | Query | Record<string, any> | string | CallbackFn,
     callback?: CallbackFn
   ): ClientRequest {
-    let parameters = '';
+    // Construct the string to use as query (GET) or body (POST).
+    let data = '';
     if (typeof query === 'function') {
       callback = query as CallbackFn;
     } else if (query instanceof Query || query instanceof Collection) {
-      parameters += query.build();
+      data = query.build();
     } else if (typeof query === 'object') {
-      parameters += querystring.stringify(query);
+      data = querystring.stringify(query);
     } else {
       // query is a string.
-      parameters += query;
+      data = query;
     }
 
-    const fullPath =
-      this.getFullHandlerPath(handler) + '?' + parameters + '&wt=json';
+    const path = this.getFullHandlerPath(handler);
+    const queryString = data + '&wt=json';
 
+    // Decide whether to use GET or POST, based on the length of the data.
+    // 10 accounts for protocol and special characters like ://, port colon,
+    // initial slash, etc.
     const approxUrlLength =
       10 +
       Buffer.byteLength(this.options.host) +
-      (this.options.port + '').length +
-      Buffer.byteLength(fullPath); // Buffer (10) accounts for protocol and special characters like ://, port colon, and initial slash etc
+      this.options.port.toString().length +
+      Buffer.byteLength(path) +
+      1 +
+      Buffer.byteLength(queryString);
+    const method =
+      this.options.get_max_request_entity_size === false ||
+      approxUrlLength <= this.options.get_max_request_entity_size
+        ? 'GET'
+        : 'POST';
 
-    if (
-      !(
-        this.options.get_max_request_entity_size === false ||
-        approxUrlLength <= this.options.get_max_request_entity_size
-      )
-    ) {
-      // Funnel this through a POST because it's too large
-      return this.post(handler, query, callback);
-    }
-
-    const requestOptions: RequestOptions = {
-      host: this.options.host,
-      port: this.options.port,
-      path: fullPath,
-      headers: {
-        accept: 'application/json; charset=utf-8',
-      },
-      family: this.options.ipVersion,
-
-      // Allow these to override (not merge with) previous values.
-      ...this.options.request,
-    };
-    if (this.options.agent) {
-      requestOptions.agent = this.options.agent;
-    }
-    if (this.options.authorization) {
-      if (!requestOptions.headers) {
-        requestOptions.headers = {};
-      }
-      requestOptions.headers.authorization = this.options.authorization;
-    }
-
-    const request = pickProtocol(this.options.secure).get(requestOptions);
-    request.on(
-      'response',
-      handleJSONResponse(request, this.options.bigint, callback)
+    return this.doRequest(
+      method === 'GET' ? `${path}?${queryString}` : path,
+      method,
+      method === 'POST' ? data : null,
+      method === 'POST'
+        ? 'application/x-www-form-urlencoded; charset=utf-8'
+        : null,
+      'application/json; charset=utf-8',
+      callback
     );
-    request.on('error', function (err) {
-      if (callback) {
-        callback(err, null);
-      }
-    });
-    return request;
-  }
-
-  /**
-   * Perform an arbitrary query on a Solr handler (a.k.a. 'path').
-   *
-   * This serves the same purpose as the `get` method, except it uses POST to
-   * transfer the data instead of putting all of the data in the URL.
-   *
-   * @param handler
-   *   The name of the handler (or 'path' in Solr terminology).
-   * @param query
-   *   A function, Query object, Collection object, plain object, or string
-   *   describing the query to perform.
-   * @param callback
-   *   A function to execute when the Solr server responds or an error occurs.
-   */
-  post(
-    handler: string,
-    query: Collection | Query | Record<string, any> | string | CallbackFn,
-    callback?: CallbackFn
-  ): ClientRequest {
-    let parameters = '';
-    if (typeof query === 'function') {
-      callback = query as CallbackFn;
-    } else if (query instanceof Query || query instanceof Collection) {
-      parameters += query.build();
-    } else if (typeof query === 'object') {
-      parameters += querystring.stringify(query);
-    } else {
-      // query is a string.
-      parameters += query;
-    }
-    let pathArray;
-
-    if (handler != 'admin/collections') {
-      pathArray = [this.options.path, this.options.core, handler + '?wt=json'];
-    } else {
-      pathArray = [this.options.path, handler + '?wt=json'];
-    }
-
-    const fullPath = pathArray
-      .filter(function (element) {
-        return element;
-      })
-      .join('/');
-
-    const requestOptions: RequestOptions = {
-      host: this.options.host,
-      port: this.options.port,
-      method: 'POST',
-      headers: {
-        'content-type': 'application/x-www-form-urlencoded; charset=utf-8',
-        'content-length': Buffer.byteLength(parameters),
-        accept: 'application/json; charset=utf-8',
-      },
-      path: fullPath,
-      family: this.options.ipVersion,
-
-      // Allow these to override (not merge with) previous values.
-      ...this.options.request,
-    };
-    if (this.options.agent) {
-      requestOptions.agent = this.options.agent;
-    }
-    if (this.options.authorization) {
-      if (!requestOptions.headers) {
-        requestOptions.headers = {};
-      }
-      requestOptions.headers.authorization = this.options.authorization;
-    }
-
-    const request = pickProtocol(this.options.secure).request(requestOptions);
-    request.on(
-      'response',
-      handleJSONResponse(request, this.options.bigint, callback)
-    );
-    request.on('error', function onError(err) {
-      if (callback) callback(err, null);
-    });
-
-    request.write(parameters);
-    request.end();
-
-    return request;
   }
 
   /**
@@ -943,68 +880,45 @@ export class Client {
     return this.doQuery(this.ADMIN_PING_HANDLER, callback);
   }
 
-  createSchemaField(
+  /**
+   * Utility only used in tests.
+   *
+   * @param {string} fieldName
+   *   The name of the field to create.
+   * @param {string} fieldType
+   *   The type of field to create.
+   * @param {Function} cb
+   *   A callback to run when completed.
+   */
+  private createSchemaField(
     fieldName: string,
     fieldType: string,
     cb: CallbackFn
-  ): void {
-    const json = JSON.stringify({
-      'add-field': {
-        name: fieldName,
-        type: fieldType,
-        multiValued: false,
-        stored: true,
-      },
-    });
-
-    const callback = (err, result) => {
-      if (err) {
-        // ToDo We should handle this in a more robust way in the future, but
-        // there is a difference between default setup in Solr 5 and Solr 8, so
-        // some fields already exist in Solr 8. Hence if that's the case, we just
-        // ignore that.
-        console.warn(err.message);
+  ): ClientRequest {
+    return this.doRequest(
+      this.getFullHandlerPath('schema'),
+      'POST',
+      pickJSON(this.options.bigint).stringify({
+        'add-field': {
+          name: fieldName,
+          type: fieldType,
+          multiValued: false,
+          stored: true,
+        },
+      }),
+      'application/json',
+      'application/json; charset=utf-8',
+      (err, data) => {
+        if (err) {
+          // TODO: We should handle this in a more robust way in the future, but
+          //   there is a difference between default setup in Solr 5 and Solr 8,
+          // so some fields already exist in Solr 8. Hence if that's the case, we
+          // just ignore that.
+          console.warn(err.message);
+        }
+        cb(undefined, data);
       }
-      cb(undefined, result);
-    };
-
-    const fullPath = this.getFullHandlerPath('schema');
-
-    const requestOptions: RequestOptions = {
-      host: this.options.host,
-      port: this.options.port,
-      method: 'POST',
-      headers: {
-        'content-type': 'application/json; charset=utf-8',
-        'content-length': Buffer.byteLength(json),
-        accept: 'application/json; charset=utf-8',
-      },
-      path: fullPath,
-      family: this.options.ipVersion,
-    };
-    if (this.options.agent) {
-      requestOptions.agent = this.options.agent;
-    }
-    if (this.options.authorization) {
-      if (!requestOptions.headers) {
-        requestOptions.headers = {};
-      }
-      requestOptions.headers.authorization = this.options.authorization;
-    }
-
-    const request = pickProtocol(this.options.secure).request(requestOptions);
-    request.on(
-      'response',
-      handleJSONResponse(request, this.options.bigint, callback)
     );
-    request.on('error', function onError(err) {
-      if (callback) callback(err, null);
-    });
-
-    request.write(json);
-    request.end();
-
-    return request;
   }
 }
 

--- a/lib/solr.ts
+++ b/lib/solr.ts
@@ -553,19 +553,19 @@ export class Client {
    *
    * @param data
    *   The data to stringify in the body.
-   * @param options
+   * @param queryParameters
    *   Query parameters to include in the URL.
    * @param callback
    *   A function to execute when the Solr server responds or an error occurs.
    */
   update(
     data: Record<string, any>,
-    options?: Record<string, any> | CallbackFn,
+    queryParameters?: Record<string, any> | CallbackFn,
     callback?: any
   ): ClientRequest {
-    if (typeof options === 'function') {
-      callback = options;
-      options = {};
+    if (typeof queryParameters === 'function') {
+      callback = queryParameters;
+      queryParameters = {};
     }
 
     const json = pickJSON(this.options.bigint).stringify(data);
@@ -574,7 +574,7 @@ export class Client {
       this.options.core,
       this.UPDATE_JSON_HANDLER +
         '?' +
-        querystring.stringify({ ...options, wt: 'json' }),
+        querystring.stringify({ ...queryParameters, wt: 'json' }),
     ]
       .filter(function (element) {
         return element;

--- a/test/get-test.ts
+++ b/test/get-test.ts
@@ -15,18 +15,18 @@ const basePath = [config.client.path, config.client.core]
   .replace(/\/$/, '');
 
 describe('Client', function () {
-  describe('#get("admin/ping",callback)', function () {
+  describe('#doQuery("admin/ping",callback)', function () {
     it('should ping', function (done) {
-      client.get('admin/ping', function (err, data) {
+      client.doQuery('admin/ping', function (err, data) {
         sassert.ok(err, data);
         assert.equal(data.status, 'OK');
         done();
       });
     });
   });
-  describe('#get("update/json", "softCommit=true", callback)', function () {
+  describe('#doQuery("update/json", "softCommit=true", callback)', function () {
     it('should soft commit', function (done) {
-      const request = client.get(
+      const request = client.doQuery(
         'update/json',
         'softCommit=true',
         function (err, data) {
@@ -40,12 +40,12 @@ describe('Client', function () {
       );
     });
   });
-  describe('#get("select", query, callback)', function () {
+  describe('#doQuery("select", query, callback)', function () {
     it('should find documents describe in the `query` instance of `Query`', function (done) {
       const query = client.createQuery().q({
         title_t: 'test',
       });
-      client.get('select', query, function (err, data) {
+      client.doQuery('select', query, function (err, data) {
         assert.deepEqual(
           { q: 'title_t:test', wt: 'json' },
           data.responseHeader.params


### PR DESCRIPTION
Previously, we had `.get` and `.post`, which did something like this:

`get`:
- Build a query.
- If the URL is too large, throw everything away and call post.
- Perform HTTP GET.

`post`:
- Build a query.
- Perform HTTP POST.

The problem with this is that neither GET nor POST what one would expect:
- Neither are general HTTP GET or POST utilities.
- They work specifically with Solr Query objects.
- They expect JSON responses only.
- They send their data as query strings only (even .post, which uses `application/x-www-form-urlencoded`).

Therefore this can be much better encapsulated as:

`doQuery`:
- Take a Solr Query object, and prepare data for an HTTP query from that.
- Decide whether GET or POST should be used (note that this behaviour comes from https://github.com/lbdremy/solr-node-client/pull/129 – I did not invent it)
- Call `doRequest`.

`doRequest`:
- Build the query.
- Send the query.

This maintains a [single level of abstraction per method](http://www.principles-wiki.net/principles:single_level_of_abstraction), and therefore gives better separation of concerns and results in more understandable code.