### PR TITLE
Strict function arguments for the `doQuery` and `createClient` methods.

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -36,15 +36,15 @@ The only breaking change introduced in `0.5.x` is introduced in this commit [3cb
 For example, for some weird reason you wanted to escape the special char `*`, don't ask me ;)
 
 ```js
-const query = client.createQuery();
-query.q({ '*' : '*' }).rangeFilter({ field : 'id', start : 100, end : '*'})
+const query = client.query();
+query.q({ '*': '*' }).rangeFilter({ field: 'id', start: 100, end: '*' })
 ```
 
 You still can:
 
 ```js
-const query = client.createQuery();
-query.q({ '*' : '*' }).rangeFilter({ field : 'id', start : 100, end : solr.escapeSpecialChars('*')})
+const query = client.query();
+query.q({ '*': '*' }).rangeFilter({ field: 'id', start: 100, end: solr.escapeSpecialChars('*') })
 ```
 
 Post an issue if you have troubles migrating to v0.5.0.

--- a/examples/basicAuth.js
+++ b/examples/basicAuth.js
@@ -11,7 +11,7 @@ client.basicAuth('admin', 'passtest');
 
 // You can now search documents using your credentials
 const query = client
-  .createQuery()
+  .query()
   .q('laptop')
   .dismax()
   .qf({ title_t: 0.2, description_t: 3.3 })

--- a/examples/facet.js
+++ b/examples/facet.js
@@ -2,7 +2,7 @@
 const solr = require('../lib/solr');
 
 const client = solr.createClient();
-const query = client.createQuery().q('*:*').rows(0).facet({
+const query = client.query().q('*:*').rows(0).facet({
   field: 'title',
   prefix: 'Ipa',
   query: 'title:Ipad',

--- a/examples/highlightQuery.js
+++ b/examples/highlightQuery.js
@@ -2,7 +2,7 @@
 const solr = require('../lib/solr');
 
 const client = solr.createClient();
-const query = client.createQuery().q('*:*').rows(0).hl({
+const query = client.query().q('*:*').rows(0).hl({
   on: true,
   q: 'title:An Example Title to Highlight',
   fl: 'title',

--- a/examples/search.js
+++ b/examples/search.js
@@ -7,7 +7,7 @@ const client = solr.createClient();
 
 // DixMax query
 const query = client
-  .createQuery()
+  .query()
   .q('laptop')
   .dismax()
   .qf({ title_t: 0.2, description_t: 3.3 })
@@ -23,7 +23,7 @@ client.search(query, function (err, obj) {
 });
 
 // Lucene query
-const query2 = client.createQuery().q({ title_t: 'laptop' }).start(0).rows(10);
+const query2 = client.query().q({ title_t: 'laptop' }).start(0).rows(10);
 client.search(query2, function (err, obj) {
   if (err) {
     console.log(err);
@@ -42,7 +42,7 @@ client.search(query2, function (err, obj) {
  * @author Tolga Akyüz <me@tolgaakyuz.org>
  */
 const query3 = client
-  .createQuery()
+  .query()
   .q('laptop')
   .edismax()
   .qf({ title_t: 0.2, description_t: 3.3 })
@@ -70,7 +70,7 @@ client.search(query3, function (err, obj) {
  * @author Tolga Akyüz <me@tolgaakyuz.org>
  */
 const query4 = client
-  .createQuery()
+  .query()
   .q('laptop')
   .edismax()
   .qf({ title_t: 0.2, description_t: 3.3 })

--- a/examples/spell.js
+++ b/examples/spell.js
@@ -4,7 +4,7 @@
 const solr = require('../lib/solr');
 
 const client = solr.createClient();
-const query = client.createQuery().q('laptop');
+const query = client.query().q('laptop');
 client.spell(query, function (err, obj) {
   if (err) {
     console.log(err);

--- a/lib/query.ts
+++ b/lib/query.ts
@@ -211,7 +211,7 @@ export class Query {
    * @api public
    *
    * @example
-   * var query = client.createQuery();
+   * var query = client.query();
    * query.q({ '*' : '*' }).rangeFilter({ field : 'id', start : 100, end : 200})
    * // also works
    * query.q({ '*' : '*' }).rangeFilter([{ field : 'id', start : 100, end : 200},{ field : 'date', start : new Date(), end : new Date() - 3600}]);
@@ -255,7 +255,7 @@ export class Query {
    * @api public
    *
    * @example
-   * var query = client.createQuery();
+   * var query = client.query();
    * query.q({ '*' : '*' }).matchFilter('id', 100)
    */
 
@@ -280,7 +280,7 @@ export class Query {
    * @api public
    *
    * @example
-   * var query = client.createQuery();
+   * var query = client.query();
    * query.q({ '*' : '*' }).fq({field: 'id', value: 100})
    * query.q({ '*' : '*' }).fq([{field: 'id', value: 100}, {field: 'name', value: 'John'}])
    */
@@ -630,7 +630,7 @@ export class Query {
    * @api public
    *
    * @example
-   * const query = client.createQuery();
+   * const query = client.query();
    * query.qf({title : 2.2, description : 0.5 });
    */
 
@@ -651,7 +651,7 @@ export class Query {
    * @api public
    *
    * @example
-   * var query = client.createQuery();
+   * var query = client.query();
    * query.mm(2); // or query.mm('75%');
    */
 

--- a/lib/solr.ts
+++ b/lib/solr.ts
@@ -1,4 +1,3 @@
-import type * as http from 'http';
 import type { RequestOptions } from 'http';
 import { ClientRequest } from 'http';
 import * as querystring from 'querystring';
@@ -19,86 +18,25 @@ const bluebird = require('bluebird');
 const format = require('./utils/format');
 const { handleJSONResponse, pickJSON, pickProtocol } = require('./client');
 
-/**
- * Create an instance of `Client`
- *
- * @param {String|Object} [hostOrParams='127.0.0.1'] - IP address or host address of the Solr server
- * @param {Number|String} [port='8983'] - port of the Solr server
- * @param {String} [core=''] - name of the Solr core requested
- * @param {String} [path='/solr'] - root path of all requests
- * @param {http.Agent} [agent] - HTTP Agent which is used for pooling sockets used in HTTP(s) client requests
- * @param {Boolean} [secure=false] - if true HTTPS will be used instead of HTTP
- * @param {Boolean} [bigint=false] - if true JSONbig serializer/deserializer will be used instead
- *                                    of JSON native serializer/deserializer
- * @param solrVersion ['3.2', '4.0', '5.0', '5.1'], check lib/utils/version.ts for full reference
- * @param {Number} [ipVersion=4] - pass it to http/https lib's "family" option
- * @param {Object} request - request options
- *
- * @return {Client}
- * @api public
- */
-
-export function createClient(
-  hostOrParams: string | SolrClientParams,
-  port?: number | string,
-  core?: string,
-  path?: string,
-  agent?: http.Agent,
-  secure?: boolean,
-  bigint?: boolean,
-  solrVersion?: number,
-  ipVersion?: number,
-  request?: Record<string, any>
-): Client {
-  const options =
-    typeof hostOrParams === 'object'
-      ? hostOrParams
-      : {
-          host: hostOrParams,
-          port: port,
-          core: core,
-          path: path,
-          agent: agent,
-          secure: secure,
-          bigint: bigint,
-          solrVersion: solrVersion,
-          ipVersion: ipVersion == 6 ? 6 : 4,
-          request: request,
-        };
+export function createClient(options: SolrClientParams = {}) {
   return new Client(options);
 }
 
 /**
- * Solr client
- * @constructor
- *
- * @param {Object} options - set of options used to request the Solr server
- * @param {String} options.host - IP address or host address of the Solr server
- * @param {Number|String} options.port - port of the Solr server, 0 to be ignored by HTTP agent in case of using API endpoint.
- * @param {String} options.core - name of the Solr core requested
- * @param {String} options.path - root path of all requests
- * @param {http.Agent} [options.agent] - HTTP Agent which is used for pooling sockets used in HTTP(s) client requests
- * @param {Boolean} [options.secure=false] - if true HTTPS will be used instead of HTTP
- * @param {Boolean} [options.bigint=false] - if true JSONbig serializer/deserializer will be used instead
- *                                    of JSON native serializer/deserializer
- * @param {Object} options.request - request options
- * @param {Number} [ipVersion=4] - pass it to http/https lib's "family" option
- *
- * @api private
+ * Solr client.
  */
-
 export class Client {
-  private options: FullSolrClientParams;
-  private UPDATE_JSON_HANDLER: string;
-  private UPDATE_HANDLER: string;
-  private TERMS_HANDLER: string;
-  private SPELL_HANDLER: string;
-  private REAL_TIME_GET_HANDLER: string;
-  private ADMIN_PING_HANDLER: string;
-  private COLLECTIONS_HANDLER: string;
-  private SELECT_HANDLER: string;
+  private readonly options: FullSolrClientParams;
+  private readonly UPDATE_JSON_HANDLER: string;
+  private readonly UPDATE_HANDLER: string;
+  private readonly TERMS_HANDLER: string;
+  private readonly SPELL_HANDLER: string;
+  private readonly REAL_TIME_GET_HANDLER: string;
+  private readonly ADMIN_PING_HANDLER: string;
+  private readonly COLLECTIONS_HANDLER: string;
+  private readonly SELECT_HANDLER: string;
 
-  constructor(options: SolrClientParams) {
+  constructor(options: SolrClientParams = {}) {
     this.options = {
       host: options.host || '127.0.0.1',
       port: options.port === 0 ? 0 : options.port || '8983',
@@ -798,7 +736,7 @@ export class Client {
     }
 
     const path = this.getFullHandlerPath(handler);
-    const queryString = data + '&wt=json';
+    const queryString = data ? data + '&wt=json' : 'wt=json';
 
     // Decide whether to use GET or POST, based on the length of the data.
     // 10 accounts for protocol and special characters like ://, port colon,

--- a/lib/solr.ts
+++ b/lib/solr.ts
@@ -666,14 +666,6 @@ export class Client {
   }
 
   /**
-   * Create an instance of `Query`.
-   * NOTE: This method will be deprecated in the v0.6 release. Please use `Client.query()` instead.
-   */
-  createQuery(): Query {
-    return new Query(this.options);
-  }
-
-  /**
    * Create an instance of `Collection`.
    */
   collection(): Collection {

--- a/lib/solr.ts
+++ b/lib/solr.ts
@@ -611,14 +611,12 @@ export class Client {
    */
   doQuery(
     handler: string,
-    query: Collection | Query | Record<string, any> | string | CallbackFn,
-    callback?: CallbackFn
+    query: Collection | Query | Record<string, any> | string,
+    callback: CallbackFn | undefined
   ): ClientRequest {
     // Construct the string to use as query (GET) or body (POST).
-    let data = '';
-    if (typeof query === 'function') {
-      callback = query as CallbackFn;
-    } else if (query instanceof Query || query instanceof Collection) {
+    let data: string;
+    if (query instanceof Query || query instanceof Collection) {
       data = query.build();
     } else if (typeof query === 'object') {
       data = querystring.stringify(query);
@@ -684,7 +682,7 @@ export class Client {
    *   A function to execute when the Solr server responds or an error occurs.
    */
   ping(callback: CallbackFn) {
-    return this.doQuery(this.ADMIN_PING_HANDLER, callback);
+    return this.doQuery(this.ADMIN_PING_HANDLER, '', callback);
   }
 
   /**

--- a/lib/solr.ts
+++ b/lib/solr.ts
@@ -890,7 +890,7 @@ export class Client {
    * @param {Function} cb
    *   A callback to run when completed.
    */
-  private createSchemaField(
+  public createSchemaField(
     fieldName: string,
     fieldType: string,
     cb: CallbackFn

--- a/lib/solr.ts
+++ b/lib/solr.ts
@@ -161,9 +161,7 @@ export class Client {
 
   /**
    * Create credential using the basic access authentication method
-   * @api public
    */
-
   basicAuth(username: string, password: string): Client {
     this.options.authorization =
       'Basic ' + Buffer.from(username + ':' + password).toString('base64');
@@ -172,27 +170,21 @@ export class Client {
 
   /**
    * Remove authorization header
-   * @api public
    */
-
   unauth(): Client {
     delete this.options.authorization;
     return this;
   }
 
   /**
-   * Add a document or a list of documents
+   * Add a document or a list of documents.
    *
-   * @param {Object|Array} doc - document or list of documents to add into the Solr database
-   * @param {Object} [options] -
-   * @param {Function} callback(err,obj) - a function executed when the Solr server responds or an error occurs
-   * @param {Error} callback().err
-   * @param {Object} callback().obj - JSON response sent by the Solr server deserialized
-   *
-   * @return {http.ClientRequest}
-   * @api public
+   * @param docs
+   *   Document or list of documents to add into the Solr database.
+   * @param options
+   * @param callback
+   *   A function to execute when the Solr server responds or an error occurs.
    */
-
   add(
     docs: Record<string, any> | Record<string, any>[],
     options?: Record<string, any> | CallbackFn,
@@ -208,17 +200,9 @@ export class Client {
   }
 
   /**
-   * Updates a document or a list of documents Solr 4.0+
-   * This function is a clone of add and it was added to give more clarity on the availability of atomic updates.
+   * Updates a document or a list of documents.
    *
-   * @param {Object|Array} doc - document or list of documents to be updated into the Solr database (set, inc, add)
-   * @param {Object} [options] -
-   * @param {Function} callback(err,obj) - a function executed when the Solr server responds or an error occurs
-   * @param {Error} callback().err
-   * @param {Object} callback().obj - JSON response sent by the Solr server deserialized
-   *
-   * @return {http.ClientRequest}
-   * @api public
+   * This function is a clone of `add` and it was added to give more clarity on the availability of atomic updates.
    */
   atomicUpdate = Client.prototype.add;
 
@@ -226,16 +210,12 @@ export class Client {
    * Get a document by id or a list of documents by ids using the Real-time-get feature
    *  in SOLR4 (https://wiki.apache.org/solr/RealTimeGet)
    *
-   * @param {String|Array} ids - id or list of ids that identify the documents to get
-   * @param {Query|Object|String} [query] -
-   * @param {Function} callback(err,obj) - a function executed when the Solr server responds or an error occurs
-   * @param {Error} callback().err
-   * @param {Object} callback().obj - JSON response sent by the Solr server deserialized
-   *
-   * @return {http.ClientRequest}
-   * @api public
+   * @param ids
+   *   ID or list of IDs that identify the documents to get.
+   * @param query
+   * @param callback
+   *   A function to execute when the Solr server responds or an error occurs.
    */
-
   realTimeGet(
     ids: string | string[],
     query?: Query | Record<string, any> | string,
@@ -259,19 +239,10 @@ export class Client {
   /**
    * Add the remote resource located at the given path `options.path` into the Solr database.
    *
-   * @param {Object} options -
-   * @param {String} options.path - path of the file. HTTP URL, the full path or a path relative to the CWD of the running solr server must be used.
-   * @param {String} [options.format='xml'] - format of the resource. XML, CSV or JSON formats must be used.
-   * @param {String} [options.contentType='text/plain;charset=utf-8'] - content type of the resource
-   * @param {Object} [options.parameters] - set of extras parameters pass along in the query.
-   * @param {Function} callback(err,obj) - a function executed when the Solr server responds or an error occurs
-   * @param {Error} callback().err
-   * @param {Object} callback().obj - JSON response sent by the Solr server deserialized
-   *
-   * @return {http.ClientRequest}
-   * @api public
+   * @param options
+   * @param callback
+   *   A function to execute when the Solr server responds or an error occurs.
    */
-
   addRemoteResource(
     options: ResourceOptions,
     callback: CallbackFn
@@ -296,14 +267,8 @@ export class Client {
   }
 
   /**
-   * Create a writable/readable `Stream` to add documents into the Solr database
-   *
-   * @param {Object} [options] -
-   *
-   * return {Stream}
-   * @api public
+   * Create a writable/readable `Stream` to add documents into the Solr database.
    */
-
   createAddStream(options: Record<string, any>) {
     const path = [
       this.options.path,
@@ -333,22 +298,16 @@ export class Client {
     const jsonStreamStringify = JSONStream.stringify();
     const postRequest = request(optionsRequest);
     jsonStreamStringify.pipe(postRequest);
-    const duplex = duplexer(jsonStreamStringify, postRequest);
-    return duplex;
+    return duplexer(jsonStreamStringify, postRequest);
   }
 
   /**
    * Commit last added and removed documents, that means your documents are now indexed.
    *
-   * @param {Object} options
-   * @param {Function} callback(err,obj) - a function executed when the Solr server responds or an error occurs
-   * @param {Error} callback().err
-   * @param {Object} callback().obj - JSON response sent by the Solr server deserialized
-   *
-   * @return {http.ClientRequest}
-   * @api public
+   * @param options
+   * @param callback
+   *   A function to execute when the Solr server responds or an error occurs.
    */
-
   commit(
     options: Record<string, any> | CallbackFn,
     callback: CallbackFn
@@ -366,14 +325,9 @@ export class Client {
   /**
    * Call Lucene's IndexWriter.prepareCommit, the changes won't be visible in the index.
    *
-   * @param {Function} callback(err,obj) - a function executed when the Solr server responds or an error occurs
-   * @param {Error} callback().err
-   * @param {Object} callback().obj - JSON response sent by the Solr server deserialized
-   *
-   * @return {http.ClientRequest}
-   * @api public
+   * @param callback
+   *   A function to execute when the Solr server responds or an error occurs.
    */
-
   prepareCommit(callback: CallbackFn): ClientRequest {
     return this.update({}, { prepareCommit: true }, callback);
   }
@@ -381,14 +335,9 @@ export class Client {
   /**
    * Soft commit all changes
    *
-   * @param {Function} callback(err,obj) - a function executed when the Solr server responds or an error occurs
-   * @param {Error} callback().err
-   * @param {Object} callback().obj - JSON response sent by the Solr server deserialized
-   *
-   * @return {http.ClientRequest}
-   * @api public
+   * @param callback
+   *   A function to execute when the Solr server responds or an error occurs.
    */
-
   softCommit(callback: CallbackFn): ClientRequest {
     return this.update({}, { softCommit: true }, callback);
   }
@@ -396,17 +345,12 @@ export class Client {
   /**
    * Delete documents based on the given `field` and `text`.
    *
-   * @param {String} field
-   * @param {String} text
-   * @param {Object} [options]
-   * @param {Function} callback(err,obj) - a function executed when the Solr server responds or an error occurs
-   * @param {Error} callback().err
-   * @param {Object} callback().obj - JSON response sent by the Solr server deserialized
-   *
-   * @return {http.ClientRequest}
-   * @api public
+   * @param field
+   * @param text
+   * @param options
+   * @param callback
+   *   A function to execute when the Solr server responds or an error occurs.
    */
-
   delete(
     field: string,
     text: string,
@@ -429,17 +373,13 @@ export class Client {
   /**
    * Delete a range of documents based on the given `field`, `start` and `stop` arguments.
    *
-   * @param {String} field
-   * @param {String|Date} start
-   * @param {String|Date} stop
-   * @param {Function} callback(err,obj) - a function executed when the Solr server responds or an error occurs
-   * @param {Error} callback().err
-   * @param {Object} callback().obj - JSON response sent by the Solr server deserialized
-   *
-   * @return {http.ClientRequest}
-   * @api public
+   * @param field
+   * @param start
+   * @param stop
+   * @param options
+   * @param callback
+   *   A function to execute when the Solr server responds or an error occurs.
    */
-
   deleteByRange(
     field: string,
     start: string | Date,
@@ -461,16 +401,12 @@ export class Client {
   /**
    * Delete the document with the given `id`
    *
-   * @param {String|Number} id - id of the document you want to delete
-   * @param {Object} [options] -
-   * @param {Function} callback(err,obj) - a function executed when the Solr server responds or an error occurs
-   * @param {Error} callback().err
-   * @param {Object} callback().obj - JSON response sent by the Solr server deserialized
-   *
-   * @return {http.ClientRequest}
-   * @api public
+   * @param id
+   *   ID of the document you want to delete.
+   * @param options
+   * @param callback
+   *   A function to execute when the Solr server responds or an error occurs.
    */
-
   deleteByID(
     id: string | number,
     options?: Record<string, any> | CallbackFn,
@@ -489,18 +425,13 @@ export class Client {
   }
 
   /**
-   * Delete documents matching the given `query`
+   * Delete documents matching the given `query`.
    *
-   * @param {String} query -
-   * @param {Object} [options] -
-   * @param {Function} callback(err,obj) - a function executed when the Solr server responds or an error occurs
-   * @param {Error} callback().err
-   * @param {Object} callback().obj - JSON response sent by the Solr server deserialized
-   *
-   * @return {http.ClientRequest}
-   * @api public
+   * @param query
+   * @param options
+   * @param callback
+   *   A function to execute when the Solr server responds or an error occurs.
    */
-
   deleteByQuery(
     query: string,
     options?: Record<string, any> | CallbackFn,
@@ -519,17 +450,12 @@ export class Client {
   }
 
   /**
-   * Delete all documents
+   * Delete all documents.
    *
-   * @param {Object} [options] -
-   * @param {Function} callback(err,obj) - a function executed when the Solr server responds or an error occurs
-   * @param {Error} callback().err
-   * @param {Object} callback().obj - JSON response sent by the Solr server deserialized
-   *
-   * @return {http.ClientRequest}
-   * @api public
+   * @param options
+   * @param callback
+   *   A function to execute when the Solr server responds or an error occurs.
    */
-
   deleteAll(
     options: Record<string, any> | CallbackFn,
     callback: CallbackFn
@@ -538,17 +464,12 @@ export class Client {
   }
 
   /**
-   * Optimize the index
+   * Optimize the index.
    *
-   * @param {Object} options -
-   * @param {Function} callback(err,obj) - a function executed when the Solr server responds or an error occurs
-   * @param {Error} callback().err
-   * @param {Object} callback().obj - JSON response sent by the Solr server deserialized
-   *
-   * @return {http.ClientRequest}
-   * @api public
+   * @param options
+   * @param callback
+   *   A function to execute when the Solr server responds or an error occurs.
    */
-
   optimize(
     options: Record<string, any> | CallbackFn,
     callback: CallbackFn
@@ -566,13 +487,9 @@ export class Client {
   /**
    * Rollback all add/delete commands made since the last commit.
    *
-   * @param {Function} callback(err,obj) - a function executed when the Solr server responds or an error occurs
-   * @param {Error} callback().err
-   * @param {Object} callback().obj - JSON response sent by the Solr server deserialized
-   *
-   * @api public
+   * @param callback
+   *   A function to execute when the Solr server responds or an error occurs.
    */
-
   rollback(callback: CallbackFn): ClientRequest {
     const data = {
       rollback: {},
@@ -619,14 +536,10 @@ export class Client {
   /**
    * Search documents matching the `query`
    *
-   * @param {Query|Object|String} query
-   * @param {Function} callback(err,obj) - a function executed when the Solr server responds or an error occurs
-   * @param {Error} callback().err
-   * @param {Object} callback().obj - JSON response sent by the Solr server deserialized
-   *
-   * @api public
+   * @param query
+   * @param callback
+   *   A function to execute when the Solr server responds or an error occurs.
    */
-
   search(
     query: Query | Record<string, any> | string,
     callback: CallbackFn
@@ -638,13 +551,9 @@ export class Client {
    * Execute an Admin Collections task on `collection`
    *
    * @param {Query|Object|String} collection
-   * @param {Function} callback(err,obj) - a function executed when the Solr server responds or an error occurs
-   * @param {Error} callback().err
-   * @param {Object} callback().obj - JSON response sent by the Solr server deserialized
-   *
-   * @api public
+   * @param callback
+   *   A function to execute when the Solr server responds or an error occurs.
    */
-
   executeCollection(
     collection: Collection | Record<string, any> | string,
     callback: CallbackFn
@@ -653,52 +562,35 @@ export class Client {
   }
 
   /**
-   * Search for all documents
+   * Search for all documents.
    *
-   * @param {Function} callback(err,obj) - a function executed when the Solr server responds or an error occurs
-   * @param {Error} callback().err
-   * @param {Object} callback().obj - JSON response sent by the Solr server deserialized
-   *
-   * @return {http.ClientRequest}
-   * @api public
+   * @param callback
+   *   A function to execute when the Solr server responds or an error occurs.
    */
-
   searchAll(callback: CallbackFn): ClientRequest {
     return this.search('q=*', callback);
   }
 
   /**
-   * Search documents matching the `query`
+   * Search documents matching the `query`, with spellchecking enabled.
    *
-   * Spellcheck is also enabled.
-   *
-   * @param {Query|Object|String} query
-   * @param {Function} callback(err,obj) - a function executed when the Solr server responds or an error occurs
-   * @param {Error} callback().err
-   * @param {Object} callback().obj - JSON response sent by the Solr server deserialized
-   *
-   * @return {http.ClientRequest}
-   * @api public
+   * @param query
+   * @param callback
+   *   A function to execute when the Solr server responds or an error occurs.
    */
-
   spell(query: Query, callback: CallbackFn): ClientRequest {
     return this.doQuery(this.SPELL_HANDLER, query, callback);
   }
 
   /**
-   * Terms search
+   * Terms search.
    *
    * Provides access to the indexed terms in a field and the number of documents that match each term.
    *
-   * @param {Query|Object|String} query
-   * @param {Function} callback(err,obj) - a function executed when the Solr server responds or an error occurs
-   * @param {Error} callback().err
-   * @param {Object} callback().obj - JSON response sent by the Solr server deserialized
-   *
-   * @return {http.ClientRequest}
-   * @api public
+   * @param query
+   * @param callback
+   *   A function to execute when the Solr server responds or an error occurs.
    */
-
   termsSearch(
     query: Query | Record<string, any> | string,
     callback: CallbackFn
@@ -768,32 +660,22 @@ export class Client {
 
   /**
    * Create an instance of `Query`
-   *
-   * @api public
    */
   query(): Query {
     return new Query(this.options);
   }
 
   /**
-   * Create an instance of `Query`
+   * Create an instance of `Query`.
    * NOTE: This method will be deprecated in the v0.6 release. Please use `Client.query()` instead.
-   *
-   * @return {Query}
-   * @api public
    */
-
   createQuery(): Query {
     return new Query(this.options);
   }
 
   /**
-   * Create an instance of `Collection`
-   *
-   * @return {Collection}
-   * @api public
+   * Create an instance of `Collection`.
    */
-
   collection(): Collection {
     return new Collection();
   }
@@ -804,16 +686,11 @@ export class Client {
   escapeSpecialChars = format.escapeSpecialChars;
 
   /**
-   * Ping the Solr server
+   * Ping the Solr server.
    *
-   * @param {Function} callback(err,obj) - a function executed when the Solr server responds or an error occurs
-   * @param {Error} callback().err
-   * @param {Object} callback().obj - JSON response sent by the Solr server deserialized
-   *
-   * @return {http.ClientRequest}
-   * @api public
+   * @param callback
+   *   A function to execute when the Solr server responds or an error occurs.
    */
-
   ping(callback: CallbackFn) {
     return this.doQuery(this.ADMIN_PING_HANDLER, callback);
   }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -11,16 +11,63 @@ export type ResourceOptions = {
 };
 
 export type SolrClientParams = {
+  /**
+   * IP address or host ame of the Solr server.
+   */
   host?: string;
+
+  /**
+   * Port of the Solr server
+   */
   port?: string | number;
+
+  /**
+   * Name of the Solr core to use.
+   */
   core?: string;
+
+  /**
+   * Root path of all requests.
+   */
   path?: string;
+
+  /**
+   * Whether to use HTTPS.
+   */
   secure?: boolean;
+
+  /**
+   * Whether to use the JSONbig serializer/deserializer instead of the native
+   * JSON serializer/deserializer.
+   */
   bigint?: boolean;
+
+  /**
+   * HTTP Agent which is used for pooling sockets.
+   */
   agent?: HttpAgent | HttpsAgent;
+
+  /**
+   * Custom request options to use with every request.
+   */
   request?: Record<string, any> | null;
+
+  /**
+   * One of [4, 6].
+   * Passed to http/https lib's "family" option.
+   */
   ipVersion?: number;
+
+  /**
+   * One of ['3.2', '4.0', '5.0', '5.1'].
+   * Check lib/utils/version.ts for full reference.
+   */
   solrVersion?: number;
+
+  /**
+   * The maximum size for which to use GET requests.
+   * Requests larger than this will use POST.
+   */
   get_max_request_entity_size?: boolean | number;
 };
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -4,9 +4,26 @@ import type { Agent as HttpsAgent } from 'https';
 export type CallbackFn = (error: Error | undefined, result: any) => void;
 
 export type ResourceOptions = {
+  /**
+   * Set of extras parameters pass along in the query.
+   */
   parameters?: Record<string, any>;
+
+  /**
+   * Format of the resource. XML, CSV or JSON formats must be used.
+   */
   format?: string;
+
+  /**
+   * Content type of the resource. E.g. 'text/plain;charset=utf-8'.
+   */
   contentType?: string;
+
+  /**
+   * File path or HTTP URL to a remote resource.
+   *
+   * A full path or a path relative to the CWD of the running solr server must be used.
+   */
   path: string;
 };
 

--- a/test/core-query-test.ts
+++ b/test/core-query-test.ts
@@ -27,7 +27,7 @@ describe('Client#createQuery', function () {
   describe('query() with various query options', function () {
     it('basic query with multiple fields', function (done) {
       const query = client
-        .createQuery()
+        .query()
         .q({ title: 'name', author: 'me' })
         .debugQuery();
 
@@ -44,7 +44,7 @@ describe('Client#createQuery', function () {
 
     it('query sorted', function (done) {
       const query = client
-        .createQuery()
+        .query()
         .q('*:*')
         .sort({ author: 'asc' })
         .debugQuery(); // remove ', "category":"desc"' as newer solr doesn't support
@@ -62,12 +62,7 @@ describe('Client#createQuery', function () {
     });
 
     it('query with paging', function (done) {
-      const query = client
-        .createQuery()
-        .q('*:*')
-        .start(21)
-        .rows(20)
-        .debugQuery();
+      const query = client.query().q('*:*').start(21).rows(20).debugQuery();
 
       client.search(query, function (err, data) {
         sassert.ok(err, data);
@@ -84,7 +79,7 @@ describe('Client#createQuery', function () {
 
     it('query paged with cursorMark', function (done) {
       const query = client
-        .createQuery()
+        .query()
         .q('*:*')
         .start(0)
         .sort({ id: 'asc' })
@@ -106,11 +101,7 @@ describe('Client#createQuery', function () {
     });
 
     it('custom parameter setting - allows for any Filterquery(fq)', function (done) {
-      const query = client
-        .createQuery()
-        .q('*:*')
-        .set('fq=sqrt(id)')
-        .debugQuery();
+      const query = client.query().q('*:*').set('fq=sqrt(id)').debugQuery();
 
       client.search(query, function (err, data) {
         sassert.ok(err, data);
@@ -126,7 +117,7 @@ describe('Client#createQuery', function () {
 
     it('listing fields with fl', function (done) {
       const query = client
-        .createQuery()
+        .query()
         .q('*:*')
         .fl(['id', 'title*', 'score'])
         .debugQuery();
@@ -146,7 +137,7 @@ describe('Client#createQuery', function () {
     it('escapes fl parameter', function (done) {
       // if it's not escaped correctly, SOLR returns HTTP 400
       const query = client
-        .createQuery()
+        .query()
         .q('*:*')
         .fl(['id', 'score', "found_words:exists(query({!v='name:word'}))"]);
       client.search(query, function (err, data) {
@@ -161,11 +152,7 @@ describe('Client#createQuery', function () {
     });
 
     it('query with deftype', function (done) {
-      const query = client
-        .createQuery()
-        .q('*:*')
-        .defType('lucene')
-        .debugQuery();
+      const query = client.query().q('*:*').defType('lucene').debugQuery();
 
       client.search(query, function (err, data) {
         sassert.ok(err, data);
@@ -180,7 +167,7 @@ describe('Client#createQuery', function () {
     });
 
     it('query with time-allowed', function (done) {
-      const query = client.createQuery().q('*:*').timeout(1000).debugQuery();
+      const query = client.query().q('*:*').timeout(1000).debugQuery();
 
       client.search(query, function (err, data) {
         sassert.ok(err, data);
@@ -196,7 +183,7 @@ describe('Client#createQuery', function () {
 
     it('q.op - Default query-operator', function (done) {
       const query = client
-        .createQuery()
+        .query()
         .q('author:ali remy marc')
         .qop('OR')
         .debugQuery();
@@ -214,7 +201,7 @@ describe('Client#createQuery', function () {
     });
 
     it('df - Default field query', function (done) {
-      const query = client.createQuery().q('ali').df('author').debugQuery();
+      const query = client.query().q('ali').df('author').debugQuery();
 
       client.search(query, function (err, data) {
         sassert.ok(err, data);
@@ -230,7 +217,7 @@ describe('Client#createQuery', function () {
 
     it('query with range-filter', function (done) {
       const query = client
-        .createQuery()
+        .query()
         .q('*:*')
         .rangeFilter({ field: 'id', start: 100, end: 200 })
         .debugQuery();
@@ -249,7 +236,7 @@ describe('Client#createQuery', function () {
 
     it('query with match-filter', function (done) {
       const query = client
-        .createQuery()
+        .query()
         .q('*:*')
         .matchFilter('id', '19700506.173.85')
         .debugQuery();
@@ -268,7 +255,7 @@ describe('Client#createQuery', function () {
 
     it('query with multiple match-filters', function (done) {
       const query = client
-        .createQuery()
+        .query()
         .q('*:*')
         .fq([
           { field: 'id', value: '19700506.173.85' },
@@ -290,7 +277,7 @@ describe('Client#createQuery', function () {
 
     it('query with object match-filter', function (done) {
       const query = client
-        .createQuery()
+        .query()
         .q('*:*')
         .fq({ field: 'id', value: '19700506.173.85' })
         .debugQuery();

--- a/test/createClient-test.ts
+++ b/test/createClient-test.ts
@@ -33,7 +33,12 @@ describe('solr', function () {
   });
   describe('.createClient("10.10.10.10",8080,"core1","/solr4")', function () {
     it('should return a `Client` instance with the given options', function () {
-      const client = solr.createClient('10.10.10.10', 8080, 'core1', '/solr4');
+      const client = solr.createClient({
+        host: '10.10.10.10',
+        port: 8080,
+        core: 'core1',
+        path: '/solr4',
+      });
       assert.equal(client.options.host, '10.10.10.10');
       assert.equal(client.options.port, 8080);
       assert.equal(client.options.core, 'core1');

--- a/test/dismax-query-test.ts
+++ b/test/dismax-query-test.ts
@@ -15,7 +15,7 @@ const client = solr.createClient(config.client);
 describe('Client#createQuery()', function () {
   describe('.dismax().q("test")', function () {
     it('should create a dismax query', function (done) {
-      const query = client.createQuery().dismax().q('test').debugQuery();
+      const query = client.query().dismax().q('test').debugQuery();
       client.search(query, function (err, data) {
         sassert.ok(err, data);
         assert.deepEqual(data.responseHeader.params, {

--- a/test/facet-query-test.ts
+++ b/test/facet-query-test.ts
@@ -60,7 +60,7 @@ describe('Client#createQuery()', function () {
         },
       };
       const query = client
-        .createQuery()
+        .query()
         .facet(facetOptions)
         .q({ title_t: 'test' })
         .debugQuery();
@@ -133,7 +133,7 @@ describe('Client#createQuery()', function () {
         },
       };
       const query = client
-        .createQuery()
+        .query()
         .facet(facetOptions)
         .q({ title_t: 'test' })
         .debugQuery();

--- a/test/get-test.ts
+++ b/test/get-test.ts
@@ -17,7 +17,7 @@ const basePath = [config.client.path, config.client.core]
 describe('Client', function () {
   describe('#doQuery("admin/ping",callback)', function () {
     it('should ping', function (done) {
-      client.doQuery('admin/ping', function (err, data) {
+      client.doQuery('admin/ping', '', function (err, data) {
         sassert.ok(err, data);
         assert.equal(data.status, 'OK');
         done();

--- a/test/get-test.ts
+++ b/test/get-test.ts
@@ -42,7 +42,7 @@ describe('Client', function () {
   });
   describe('#doQuery("select", query, callback)', function () {
     it('should find documents describe in the `query` instance of `Query`', function (done) {
-      const query = client.createQuery().q({
+      const query = client.query().q({
         title_t: 'test',
       });
       client.doQuery('select', query, function (err, data) {

--- a/test/group-query-test.ts
+++ b/test/group-query-test.ts
@@ -16,11 +16,7 @@ const client = solr.createClient(config.client);
 describe('Client#createQuery', function () {
   describe('.groupBy(field), callback)', function () {
     it('should create a group by query', function (done) {
-      const query = client
-        .createQuery()
-        .q('test')
-        .groupBy('title_t')
-        .debugQuery();
+      const query = client.query().q('test').groupBy('title_t').debugQuery();
       client.search(query, function (err, data) {
         sassert.ok(err, data);
         assert(data.responseHeader.params.group);
@@ -49,7 +45,7 @@ describe('Client#createQuery', function () {
         cache: 50,
       };
 
-      const query = client.createQuery().group(options);
+      const query = client.query().group(options);
 
       client.search(query, function (err, data) {
         sassert.ok(err, data);

--- a/test/highlight-query-test.ts
+++ b/test/highlight-query-test.ts
@@ -39,7 +39,7 @@ describe('Client#createQuery()', function () {
         payloads: false,
       };
       const query = client
-        .createQuery()
+        .query()
         .hl(highlightOptions)
         .q({ title_t: 'test' })
         .debugQuery();
@@ -86,7 +86,7 @@ describe('Client#createQuery()', function () {
         regexMaxAnalyzedChars: 10000,
       };
       const query = client
-        .createQuery()
+        .query()
         .hl(highlightOptions)
         .q({ title_t: 'test' })
         .debugQuery();

--- a/test/mlt-query-test.ts
+++ b/test/mlt-query-test.ts
@@ -31,7 +31,7 @@ describe('Client#createQuery', function () {
       };
 
       const query = client
-        .createQuery()
+        .query()
         .mlt(options)
         .q({ title_t: 'test' })
         .debugQuery();

--- a/test/rangeFilter-test.ts
+++ b/test/rangeFilter-test.ts
@@ -17,7 +17,7 @@ describe('Client#createQuery', function () {
   describe('.rangeFilter(array)', function () {
     it('should filter a query using an array of multiple fields', function (done) {
       const query = client
-        .createQuery()
+        .query()
         .q('test')
         .rangeFilter([
           { field: 'id', start: 100, end: 200 },
@@ -38,7 +38,7 @@ describe('Client#createQuery', function () {
   describe('.rangeFilter(start, end)', function () {
     it('should filter a query using a range', function (done) {
       const query = client
-        .createQuery()
+        .query()
         .q('test')
         .rangeFilter({ field: 'id', start: 100, end: 200 });
 
@@ -49,7 +49,7 @@ describe('Client#createQuery', function () {
       });
     });
     it('should filter a query using a range when start and end values are not set', function (done) {
-      const query = client.createQuery().q('test').rangeFilter({ field: 'id' });
+      const query = client.query().q('test').rangeFilter({ field: 'id' });
 
       client.search(query, function (err, data) {
         sassert.ok(err, data);
@@ -59,7 +59,7 @@ describe('Client#createQuery', function () {
     });
     it('should filter a query using a range when start value is not set', function (done) {
       const query = client
-        .createQuery()
+        .query()
         .q('test')
         .rangeFilter({ field: 'id', end: 200 });
 
@@ -71,7 +71,7 @@ describe('Client#createQuery', function () {
     });
     it('should filter a query using a range when end value is not set', function (done) {
       const query = client
-        .createQuery()
+        .query()
         .q('test')
         .rangeFilter({ field: 'id', start: 200 });
 

--- a/test/realTimeGet-test.ts
+++ b/test/realTimeGet-test.ts
@@ -30,7 +30,7 @@ describe('Client', function () {
     });
 
     it('should not find that document in the index yet', function (done) {
-      const query = client.createQuery();
+      const query = client.query();
       query.matchFilter('id', id);
       client.search(query, function (err, data) {
         sassert.ok(err, data);

--- a/test/search-test.ts
+++ b/test/search-test.ts
@@ -24,7 +24,7 @@ describe('Client', function () {
   });
   describe('#search(query)', function () {
     it('should find documents describe in the `query` instance of `Query`', function (done) {
-      const query = client.createQuery().q({
+      const query = client.query().q({
         title_t: 'test',
       });
       client.search(query, function (err, data) {

--- a/test/spell-test.ts
+++ b/test/spell-test.ts
@@ -15,7 +15,7 @@ const client = solr.createClient(config.client);
 describe('Client', function () {
   describe('#spell', function () {
     it('should test the "/spell" query handler/ spellchecker', function (done) {
-      const query = client.createQuery().q('test');
+      const query = client.query().q('test');
       client.spell(query, function (err, data) {
         sassert.ok(err, data);
         assert.equal(0, data.responseHeader.status);

--- a/test/terms-query-test.ts
+++ b/test/terms-query-test.ts
@@ -26,7 +26,7 @@ describe('Client#createQuery', function () {
         sort: 'index',
       };
 
-      const query = client.createQuery().terms(options).debugQuery();
+      const query = client.query().terms(options).debugQuery();
 
       client.termsSearch(query, function (err, data) {
         sassert.ok(err, data);


### PR DESCRIPTION
... and also:
- tidy up a lot of doc comments
- remove a deprecated method
- tiny bugfix: createSchemaField must be public, since it's used from outside the class
- move some type documentation out of solr.ts into types.ts