### PR TITLE
Add the `SearchResponse.nextCursorMark` field when queries define `cursorMark`.

### DIFF
--- a/lib/solr.ts
+++ b/lib/solr.ts
@@ -29,6 +29,8 @@ export type SearchResult<SolrDocument> = {
 
 export type SearchResponse<SolrDocument> = {
   debug?: Record<string, any>;
+  /** If the query defined a `cursorMark` parameter then this field will be present */
+  nextCursorMark?: string;
   response: SearchResult<SolrDocument>;
   responseHeader: {
     QTime: 0;


### PR DESCRIPTION
Currently the `SearchResponse` definition is missing the `nextCursorMark` field that is present when queries use cursor based pagination instead of traditional pagination.