### PR TITLE
Mod to allow connecting without a port

### DIFF
--- a/lib/solr.ts
+++ b/lib/solr.ts
@@ -1,20 +1,20 @@
-import * as querystring from 'querystring';
-import * as JSONStream from 'JSONStream';
 import * as duplexer from 'duplexer';
-import { Query } from './query';
-import { Collection } from './collection';
-import * as versionUtils from './utils/version';
-import {
-  AddResponse,
-  CommonResponse,
-  FullSolrClientParams,
-  JsonResponseData,
-  ResourceOptions,
-  SolrClientParams,
-  UndiciRequestOptions,
-} from './types';
+import * as JSONStream from 'JSONStream';
+import * as querystring from 'querystring';
 import { Duplex } from 'stream';
-import { request, Client as UndiciClient } from 'undici';
+import { Client as UndiciClient } from 'undici';
+import { Collection } from './collection';
+import { Query } from './query';
+import {
+	AddResponse,
+	CommonResponse,
+	FullSolrClientParams,
+	JsonResponseData,
+	ResourceOptions,
+	SolrClientParams,
+	UndiciRequestOptions
+} from './types';
+import * as versionUtils from './utils/version';
 
 const oldRequest = require('request');
 const format = require('./utils/format');
@@ -106,12 +106,14 @@ export class Client {
       ? 'https://'
       : 'http://';
 
-    this.undiciClient = new UndiciClient(
-      `${urlPrefix}${this.options.host}:${this.options.port}`,
-      {
-        connect: this.options.tls,
-      }
-    );
+	  const port = options.noPort ? '' : `:${this.options.port}`;
+
+	  this.undiciClient = new UndiciClient(
+		`${urlPrefix}${this.options.host}${port}`,
+		{
+		  connect: this.options.tls,
+		}
+	  );
   }
 
   get solrVersion(): number {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,5 +1,5 @@
-import { Dispatcher } from 'undici';
 import { TlsOptions } from 'tls';
+import { Dispatcher } from 'undici';
 
 export type UndiciRequestOptions = Omit<
   Dispatcher.RequestOptions,
@@ -40,6 +40,11 @@ export type SolrClientParams = {
    * Port of the Solr server
    */
   port?: string | number;
+
+  /**
+   * Set this to true if you do not require a port to connect.
+   */
+   noPort?: boolean;
 
   /**
    * Name of the Solr core to use.


### PR DESCRIPTION
This pull request is in reference to this issue: https://github.com/lbdremy/solr-node-client/issues/327

Looks like I changed the order of the imports since I have "organize imports" turned on in vscode. Hopefully that's not a problem.