### PR TITLE
url restructure to avoid colon when port is not necessary.

### DIFF
--- a/lib/solr.ts
+++ b/lib/solr.ts
@@ -115,9 +115,11 @@ export class Client {
       : this.options.tls
       ? 'https://'
       : 'http://';
-
+    // Build url with options provided. Ignore port and colon if options.port is not provided instead of 
+    // creating invalid url. ie. https://solr.example.com:/solr
+    const url = `${urlPrefix}${this.options.host}${this.options.port !== '' ? ':' + this.options.port : ''}`
     this.undiciClient = new UndiciClient(
-      `${urlPrefix}${this.options.host}:${this.options.port}`,
+      url,
       {
         connect: this.options.tls,
       }
@@ -172,7 +174,7 @@ export class Client {
     acceptContentType: string
   ): Promise<T> {
     const protocol = this.options.secure ? 'https' : 'http';
-    const url = `${protocol}://${this.options.host}:${this.options.port}${path}`;
+    const url = `${protocol}${this.options.host}${this.options.port !== '' ? ':' + this.options.port : ''}${path}`; 
     const requestOptions: UndiciRequestOptions = {
       ...this.options.request,
       method,
@@ -323,9 +325,9 @@ export class Client {
       headers['authorization'] = this.options.authorization;
     }
     const protocol = this.options.secure ? 'https' : 'http';
+    const url = `${urlPrefix}${this.options.host}${this.options.port !== '' ? ':' + this.options.port : ''}${path}`
     const optionsRequest = {
-      url:
-        protocol + '://' + this.options.host + ':' + this.options.port + path,
+      url,
       method: 'POST',
       headers: headers,
     };

--- a/lib/solr.ts
+++ b/lib/solr.ts
@@ -81,6 +81,7 @@ export class Client {
   private readonly COLLECTIONS_HANDLER: string;
   private readonly SELECT_HANDLER: string;
   private readonly undiciClient: UndiciClient;
+  private readonly url: string;
 
   constructor(options: SolrClientParams = {}) {
     this.options = {
@@ -117,9 +118,10 @@ export class Client {
       : 'http://';
     // Build url with options provided. Ignore port and colon if options.port is not provided instead of 
     // creating invalid url. ie. https://solr.example.com:/solr
-    const url = `${urlPrefix}${this.options.host}${this.options.port !== '' ? ':' + this.options.port : ''}`
+    this.url = `${urlPrefix}${this.options.host}${this.options.port !== '' ? ':' + this.options.port : ''}`
+    
     this.undiciClient = new UndiciClient(
-      url,
+      this.url,
       {
         connect: this.options.tls,
       }
@@ -173,8 +175,7 @@ export class Client {
     bodyContentType: string | null,
     acceptContentType: string
   ): Promise<T> {
-    const protocol = this.options.secure ? 'https' : 'http';
-    const url = `${protocol}${this.options.host}${this.options.port !== '' ? ':' + this.options.port : ''}${path}`; 
+    const url = `${this.url}${path}`; 
     const requestOptions: UndiciRequestOptions = {
       ...this.options.request,
       method,
@@ -323,9 +324,8 @@ export class Client {
     };
     if (this.options.authorization) {
       headers['authorization'] = this.options.authorization;
-    }
-    const protocol = this.options.secure ? 'https' : 'http';
-    const url = `${urlPrefix}${this.options.host}${this.options.port !== '' ? ':' + this.options.port : ''}${path}`
+    } 
+    const url = `${this.url}${path}`; 
     const optionsRequest = {
       url,
       method: 'POST',
@@ -564,8 +564,8 @@ export class Client {
       1 +
       Buffer.byteLength(queryString);
     const method =
-      this.options.get_max_request_entity_size === false ||
-      approxUrlLength <= this.options.get_max_request_entity_size
+      this.options.get_max_request_entity_size === false || 
+      (typeof this.options.get_max_request_entity_size === 'number' && approxUrlLength <= this.options.get_max_request_entity_size)
         ? 'GET'
         : 'POST';
 


### PR DESCRIPTION
Refactored url generation to avoid unnecessary colon before port when solr is running in common ports (80/443). When port is null or left blank, url should not have a dangling colon at the end.